### PR TITLE
fix: preserve metadata in SummarizedExperiment conversion

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # glyexp (development version)
 
+## Minor improvements and bug fixes
+
+* `from_se()` now preserves all `SummarizedExperiment` metadata fields when converting back to an `experiment()` object. (#10)
+
 # glyexp 0.14.1
 
 ## Minor improvements and bug fixes

--- a/R/se.R
+++ b/R/se.R
@@ -152,7 +152,7 @@ from_se <- function(
   meta_data$glycan_type <- glycan_type
 
   # Create experiment object using the constructor
-  experiment(
+  exp <- experiment(
     expr_mat = expr_mat,
     sample_info = sample_info,
     var_info = var_info,
@@ -160,6 +160,8 @@ from_se <- function(
     glycan_type = glycan_type,
     check_col_types = FALSE
   )
+  exp$meta_data <- meta_data
+  exp
 }
 
 .require_se <- function() {

--- a/tests/testthat/test-se.R
+++ b/tests/testthat/test-se.R
@@ -92,6 +92,17 @@ test_that("from_se works with metadata defaults", {
   expect_equal(exp_back$meta_data$glycan_type, exp$meta_data$glycan_type)
 })
 
+test_that("from_se preserves all metadata", {
+  exp <- toy_experiment
+  exp$meta_data$instrument <- "Orbitrap"
+  exp$meta_data$analysis <- list(method = "LC-MS", version = 1)
+  se <- as_se(exp)
+
+  exp_back <- from_se(se)
+
+  expect_equal(exp_back$meta_data, exp$meta_data)
+})
+
 test_that("from_se works with empty metadata", {
   # Create a simple SummarizedExperiment without metadata
   expr_mat <- matrix(runif(12), nrow = 3, ncol = 4)


### PR DESCRIPTION
## Summary

Fix `from_se()` so converting a `SummarizedExperiment` back to a `glyexp_experiment` preserves all metadata fields, not only `exp_type` and `glycan_type`.

## Details

- Restore the complete metadata list after constructing the returned experiment object.
- Add a regression test covering scalar and nested metadata fields through the `as_se()` / `from_se()` round trip.
- Add a development NEWS entry for the bug fix. (#10)

## Verification

- `Rscript -e 'devtools::test(filter = "se")'` - 120 passed
- `Rscript -e 'devtools::test()'` - 479 passed
