### PR TITLE
fix: support trait experiment types in from_se

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 ## Minor improvements and bug fixes
 
 * `from_se()` now preserves all `SummarizedExperiment` metadata fields when converting back to an `experiment()` object. (#10)
+* `from_se()` now accepts `traitomics` and `traitproteomics` experiment types from `SummarizedExperiment` metadata. (#11)
 
 # glyexp 0.14.1
 

--- a/R/se.R
+++ b/R/se.R
@@ -74,7 +74,8 @@ as_se <- function(exp, assay_name = "counts") {
 #' @param assay_name Character string specifying which assay to use.
 #'   If NULL (default), uses the first assay.
 #' @param exp_type Character string specifying experiment type.
-#'   Must be either "glycomics", "glycoproteomics", or "others".
+#'   Must be either "glycomics", "glycoproteomics", "traitomics",
+#'   "traitproteomics", or "others".
 #'   If NULL, will try to extract from metadata, otherwise defaults to "glycomics".
 #' @param glycan_type Character string specifying glycan type.
 #'   Must be either "N", "O-GalNAc", "O-GlcNAc", "O-Man", "O-Fuc", or "O-Glc".
@@ -102,7 +103,13 @@ from_se <- function(
   checkmate::assert_string(assay_name, null.ok = TRUE)
   checkmate::assert_choice(
     exp_type,
-    c("glycomics", "glycoproteomics", "others"),
+    c(
+      "glycomics",
+      "glycoproteomics",
+      "traitomics",
+      "traitproteomics",
+      "others"
+    ),
     null.ok = TRUE
   )
   checkmate::assert_choice(
@@ -125,7 +132,7 @@ from_se <- function(
   # Validate required parameters
   checkmate::assert_choice(
     exp_type,
-    c("glycomics", "glycoproteomics", "others")
+    c("glycomics", "glycoproteomics", "traitomics", "traitproteomics", "others")
   )
   checkmate::assert_choice(
     glycan_type,

--- a/man/from_se.Rd
+++ b/man/from_se.Rd
@@ -13,7 +13,8 @@ from_se(se, assay_name = NULL, exp_type = NULL, glycan_type = NULL)
 If NULL (default), uses the first assay.}
 
 \item{exp_type}{Character string specifying experiment type.
-Must be either "glycomics", "glycoproteomics", or "others".
+Must be either "glycomics", "glycoproteomics", "traitomics",
+"traitproteomics", or "others".
 If NULL, will try to extract from metadata, otherwise defaults to "glycomics".}
 
 \item{glycan_type}{Character string specifying glycan type.

--- a/tests/testthat/test-se.R
+++ b/tests/testthat/test-se.R
@@ -103,6 +103,41 @@ test_that("from_se preserves all metadata", {
   expect_equal(exp_back$meta_data, exp$meta_data)
 })
 
+test_that("from_se accepts trait experiment types from metadata", {
+  expr_mat <- matrix(
+    1:4,
+    nrow = 2,
+    dimnames = list(c("V1", "V2"), c("S1", "S2"))
+  )
+  sample_info <- tibble::tibble(sample = c("S1", "S2"))
+  cases <- list(
+    traitomics = tibble::tibble(
+      variable = c("V1", "V2"),
+      trait = c("motif_a", "motif_b")
+    ),
+    traitproteomics = tibble::tibble(
+      variable = c("V1", "V2"),
+      protein = c("P1", "P2"),
+      protein_site = c(10L, 20L),
+      trait = c("motif_a", "motif_b")
+    )
+  )
+
+  purrr::iwalk(cases, function(var_info, exp_type) {
+    exp <- experiment(
+      expr_mat,
+      sample_info,
+      var_info,
+      exp_type = exp_type,
+      glycan_type = "N"
+    )
+    exp_back <- from_se(as_se(exp))
+
+    expect_equal(exp_back$meta_data$exp_type, exp_type)
+    expect_equal(exp_back$var_info, exp$var_info)
+  })
+})
+
 test_that("from_se works with empty metadata", {
   # Create a simple SummarizedExperiment without metadata
   expr_mat <- matrix(runif(12), nrow = 3, ncol = 4)


### PR DESCRIPTION
## Summary

Allow `from_se()` to round-trip trait experiment types from `SummarizedExperiment` metadata.

## Background

`experiment()` accepts `traitomics` and `traitproteomics`, but `from_se()` only allowed `glycomics`, `glycoproteomics`, and `others`, so valid trait experiments could be converted to `SummarizedExperiment` but not converted back.

## Details

- Expand `from_se()` `exp_type` validation to include `traitomics` and `traitproteomics`.
- Update the generated `from_se()` Rd documentation.
- Add regression coverage for `traitomics` and `traitproteomics` round trips through `as_se()` and `from_se()`.
- Add a development `NEWS.md` entry with the live PR number.

## Verification

- `Rscript -e 'devtools::document()'`
- `Rscript -e 'devtools::test(filter = "se")'` -> 124 passing tests
- `Rscript -e 'devtools::test()'` -> 483 passing tests
- `Rscript -e 'devtools::check()'` -> 0 errors, 0 warnings, 1 NOTE for system clock verification in the restricted environment