### PR TITLE
fix: require exp_type and glycan_type for from_se fallback

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@
 
 * `from_se()` now preserves all `SummarizedExperiment` metadata fields when converting back to an `experiment()` object. (#10)
 * `from_se()` now accepts `traitomics` and `traitproteomics` experiment types from `SummarizedExperiment` metadata. (#11)
+* `from_se()` now errors when `exp_type` or `glycan_type` is missing from both the function arguments and `SummarizedExperiment` metadata. (#12)
 
 # glyexp 0.14.1
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,7 +4,7 @@
 
 * `from_se()` now preserves all `SummarizedExperiment` metadata fields when converting back to an `experiment()` object. (#10)
 * `from_se()` now accepts `traitomics` and `traitproteomics` experiment types from `SummarizedExperiment` metadata. (#11)
-* `from_se()` now errors when `exp_type` or `glycan_type` is missing from both the function arguments and `SummarizedExperiment` metadata. (#12)
+* `from_se()` now errors when `exp_type` or non-`others` `glycan_type` is missing from both the function arguments and `SummarizedExperiment` metadata. (#12)
 
 # glyexp 0.14.1
 

--- a/R/se.R
+++ b/R/se.R
@@ -81,7 +81,8 @@ as_se <- function(exp, assay_name = "counts") {
 #' @param glycan_type Character string specifying glycan type.
 #'   Must be either "N", "O-GalNAc", "O-GlcNAc", "O-Man", "O-Fuc", or "O-Glc".
 #'   If not supplied, will try to extract from metadata.
-#'   If unavailable there, an error is issued.
+#'   If unavailable there, an error is issued unless `exp_type` is "others",
+#'   where `NULL` is allowed.
 #'
 #' @return An [experiment()] object.
 #'
@@ -142,7 +143,11 @@ from_se <- function(
   if (isTRUE(glycan_type_missing)) {
     glycan_type <- meta_data$glycan_type
   }
-  if (isTRUE(glycan_type_missing) && is.null(glycan_type)) {
+  if (
+    isTRUE(glycan_type_missing) &&
+      is.null(glycan_type) &&
+      exp_type != "others"
+  ) {
     cli::cli_abort(
       c(
         "{.arg glycan_type} is not available in the {.cls SummarizedExperiment} metadata.",
@@ -159,7 +164,8 @@ from_se <- function(
   )
   checkmate::assert_choice(
     glycan_type,
-    c("N", "O-GalNAc", "O-GlcNAc", "O-Man", "O-Fuc", "O-Glc")
+    c("N", "O-GalNAc", "O-GlcNAc", "O-Man", "O-Fuc", "O-Glc"),
+    null.ok = exp_type == "others"
   )
 
   # Extract expression matrix

--- a/R/se.R
+++ b/R/se.R
@@ -76,10 +76,12 @@ as_se <- function(exp, assay_name = "counts") {
 #' @param exp_type Character string specifying experiment type.
 #'   Must be either "glycomics", "glycoproteomics", "traitomics",
 #'   "traitproteomics", or "others".
-#'   If NULL, will try to extract from metadata, otherwise defaults to "glycomics".
+#'   If not supplied, will try to extract from metadata.
+#'   If unavailable there, an error is issued.
 #' @param glycan_type Character string specifying glycan type.
 #'   Must be either "N", "O-GalNAc", "O-GlcNAc", "O-Man", "O-Fuc", or "O-Glc".
-#'   If NULL, will try to extract from metadata, otherwise defaults to "N".
+#'   If not supplied, will try to extract from metadata.
+#'   If unavailable there, an error is issued.
 #'
 #' @return An [experiment()] object.
 #'
@@ -97,6 +99,9 @@ from_se <- function(
   glycan_type = NULL
 ) {
   .require_se()
+
+  exp_type_missing <- missing(exp_type)
+  glycan_type_missing <- missing(glycan_type)
 
   # Check input
   checkmate::assert_class(se, "SummarizedExperiment")
@@ -122,11 +127,29 @@ from_se <- function(
   meta_data <- S4Vectors::metadata(se)
 
   # Determine exp_type and glycan_type
-  if (is.null(exp_type)) {
-    exp_type <- meta_data$exp_type %||% "glycomics"
+  if (isTRUE(exp_type_missing)) {
+    exp_type <- meta_data$exp_type
   }
-  if (is.null(glycan_type)) {
-    glycan_type <- meta_data$glycan_type %||% "N"
+  if (is.null(exp_type)) {
+    cli::cli_abort(
+      c(
+        "{.arg exp_type} is not available in the {.cls SummarizedExperiment} metadata.",
+        "i" = "Provide it through the `exp_type` argument."
+      ),
+      call = rlang::caller_env()
+    )
+  }
+  if (isTRUE(glycan_type_missing)) {
+    glycan_type <- meta_data$glycan_type
+  }
+  if (isTRUE(glycan_type_missing) && is.null(glycan_type)) {
+    cli::cli_abort(
+      c(
+        "{.arg glycan_type} is not available in the {.cls SummarizedExperiment} metadata.",
+        "i" = "Provide it through the `glycan_type` argument."
+      ),
+      call = rlang::caller_env()
+    )
   }
 
   # Validate required parameters

--- a/man/from_se.Rd
+++ b/man/from_se.Rd
@@ -15,11 +15,13 @@ If NULL (default), uses the first assay.}
 \item{exp_type}{Character string specifying experiment type.
 Must be either "glycomics", "glycoproteomics", "traitomics",
 "traitproteomics", or "others".
-If NULL, will try to extract from metadata, otherwise defaults to "glycomics".}
+If not supplied, will try to extract from metadata.
+If unavailable there, an error is issued.}
 
 \item{glycan_type}{Character string specifying glycan type.
 Must be either "N", "O-GalNAc", "O-GlcNAc", "O-Man", "O-Fuc", or "O-Glc".
-If NULL, will try to extract from metadata, otherwise defaults to "N".}
+If not supplied, will try to extract from metadata.
+If unavailable there, an error is issued.}
 }
 \value{
 An \code{\link[=experiment]{experiment()}} object.

--- a/man/from_se.Rd
+++ b/man/from_se.Rd
@@ -21,7 +21,8 @@ If unavailable there, an error is issued.}
 \item{glycan_type}{Character string specifying glycan type.
 Must be either "N", "O-GalNAc", "O-GlcNAc", "O-Man", "O-Fuc", or "O-Glc".
 If not supplied, will try to extract from metadata.
-If unavailable there, an error is issued.}
+If unavailable there, an error is issued unless \code{exp_type} is "others",
+where \code{NULL} is allowed.}
 }
 \value{
 An \code{\link[=experiment]{experiment()}} object.

--- a/tests/testthat/test-se.R
+++ b/tests/testthat/test-se.R
@@ -188,6 +188,21 @@ test_that("from_se requires glycan_type when metadata does not provide it", {
   )
 })
 
+test_that("from_se allows missing glycan_type for others experiments", {
+  expr_mat <- matrix(
+    1:4,
+    nrow = 2,
+    dimnames = list(c("V1", "V2"), c("S1", "S2"))
+  )
+  exp <- experiment(expr_mat)
+  se <- as_se(exp)
+
+  exp_back <- from_se(se)
+
+  expect_equal(exp_back$meta_data$exp_type, "others")
+  expect_null(exp_back$meta_data$glycan_type)
+})
+
 test_that("from_se works with custom assay name", {
   exp <- toy_experiment
   se <- as_se(exp, assay_name = "intensity")

--- a/tests/testthat/test-se.R
+++ b/tests/testthat/test-se.R
@@ -168,6 +168,26 @@ test_that("from_se works with empty metadata", {
   expect_equal(exp$meta_data$glycan_type, "O-GalNAc")
 })
 
+test_that("from_se requires exp_type when metadata does not provide it", {
+  se <- as_se(toy_experiment)
+  S4Vectors::metadata(se) <- list(glycan_type = "N")
+
+  expect_error(
+    from_se(se),
+    "Provide it through the `exp_type` argument"
+  )
+})
+
+test_that("from_se requires glycan_type when metadata does not provide it", {
+  se <- as_se(toy_experiment)
+  S4Vectors::metadata(se) <- list(exp_type = "glycomics")
+
+  expect_error(
+    from_se(se),
+    "Provide it through the `glycan_type` argument"
+  )
+})
+
 test_that("from_se works with custom assay name", {
   exp <- toy_experiment
   se <- as_se(exp, assay_name = "intensity")


### PR DESCRIPTION
## Summary

Require `from_se()` callers to provide `exp_type` and `glycan_type` when those fields are not available in `SummarizedExperiment` metadata, while preserving `glycan_type = NULL` for `exp_type = "others"`.

## Rational

`from_se()` should not silently infer glycomics/N-glycan defaults for generic `SummarizedExperiment` objects. Missing experiment metadata now becomes an explicit conversion error for required fields so users provide the intended metadata through the `exp_type` and `glycan_type` arguments. `glycan_type = NULL` remains valid for generic `others` experiments because `experiment()` permits that combination.

## Details

- Removed the fallback defaults from missing `metadata(se)$exp_type` and required `metadata(se)$glycan_type`.
- Kept metadata-based conversion working when those fields are present.
- Preserved round-tripping for default `others` experiments with `glycan_type = NULL`.
- Added regression coverage for missing `exp_type`, missing non-`others` `glycan_type`, and missing `glycan_type` for `others` experiments.
- Updated the generated `from_se()` Rd documentation.
- Updated the development NEWS entry: `from_se()` now errors when `exp_type` or non-`others` `glycan_type` is missing from both function arguments and `SummarizedExperiment` metadata. (#12)

## Verification

- `Rscript -e 'devtools::test(filter = "se")'`: 128 passed, 0 failed, 0 warnings.
- `Rscript -e 'devtools::test()'`: 487 passed, 0 failed, 0 warnings.
- `Rscript -e 'devtools::check()'`: 0 errors, 0 warnings, 1 NOTE for remote system clock verification (`Unable to verify current time`).
- `air format R/se.R tests/testthat/test-se.R`: completed without output.