### PR TITLE
Use abundance as default SummarizedExperiment assay name

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,7 +5,7 @@
 ## Minor improvements and bug fixes
 
 * `as_se()` now uses `"abundance"` instead of `"counts"` as the default
-  `SummarizedExperiment` assay name (#14).
+  `SummarizedExperiment` assay name (#17).
 * The bundled `real_experiment` and `real_experiment2` datasets now use the
   current `glyrepr` structure representation (#13).
 * `from_se()` now accepts `traitomics` and `traitproteomics` experiment types

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,24 +2,17 @@
 
 ## Minor improvements and bug fixes
 
-* `as_se()` now uses `"abundance"` instead of `"counts"` as the default
-  `SummarizedExperiment` assay name (#17).
+* `as_se()` now uses `"abundance"` instead of `"counts"` as the default`SummarizedExperiment` assay name. (#17)
 
 # glyexp 0.14.2
 
 ## Minor improvements and bug fixes
 
-* The bundled `real_experiment` and `real_experiment2` datasets now use the
-  current `glyrepr` structure representation (#13).
-* `from_se()` now accepts `traitomics` and `traitproteomics` experiment types
-  from `SummarizedExperiment` metadata (#11).
-* `from_se()` now errors when `exp_type` or non-`others` `glycan_type` is
-  missing from both the function arguments and `SummarizedExperiment` metadata
-  (#12).
-* `from_se()` now preserves all `SummarizedExperiment` metadata fields when
-  converting back to an `experiment()` object (#10).
-* `real_experiment` and `real_experiment2` now print their `glyrepr` columns
-  correctly when loaded from the package (#9).
+* The bundled `real_experiment` and `real_experiment2` datasets now use the current `glyrepr` structure representation. (#13)
+* `from_se()` now accepts `traitomics` and `traitproteomics` experiment types from `SummarizedExperiment` metadata. (#11)
+* `from_se()` now errors when `exp_type` or non-`others` `glycan_type` is missing from both the function arguments and `SummarizedExperiment` metadata. (#12)
+* `from_se()` now preserves all `SummarizedExperiment` metadata fields when converting back to an `experiment()` object. (#10)
+* `real_experiment` and `real_experiment2` now print their `glyrepr` columns correctly when loaded from the package. (#9)
 
 # glyexp 0.14.1
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,11 +1,14 @@
 # glyexp (development version)
 
-# glyexp 0.14.2
-
 ## Minor improvements and bug fixes
 
 * `as_se()` now uses `"abundance"` instead of `"counts"` as the default
   `SummarizedExperiment` assay name (#17).
+
+# glyexp 0.14.2
+
+## Minor improvements and bug fixes
+
 * The bundled `real_experiment` and `real_experiment2` datasets now use the
   current `glyrepr` structure representation (#13).
 * `from_se()` now accepts `traitomics` and `traitproteomics` experiment types

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
 
 ## Minor improvements and bug fixes
 
+* `as_se()` now uses `"abundance"` instead of `"counts"` as the default
+  `SummarizedExperiment` assay name (#14).
 * The bundled `real_experiment` and `real_experiment2` datasets now use the
   current `glyrepr` structure representation (#13).
 * `from_se()` now accepts `traitomics` and `traitproteomics` experiment types

--- a/R/se.R
+++ b/R/se.R
@@ -10,7 +10,7 @@
 #'
 #' @param exp An [experiment()] object to convert.
 #' @param assay_name Character string specifying the name for the assay.
-#'   Default is "counts".
+#'   Default is "abundance".
 #'
 #' @return A `SummarizedExperiment` object.
 #'
@@ -20,7 +20,7 @@
 #' se
 #'
 #' @export
-as_se <- function(exp, assay_name = "counts") {
+as_se <- function(exp, assay_name = "abundance") {
   .require_se()
 
   # Check input

--- a/man/as_se.Rd
+++ b/man/as_se.Rd
@@ -4,13 +4,13 @@
 \alias{as_se}
 \title{Convert experiment to SummarizedExperiment}
 \usage{
-as_se(exp, assay_name = "counts")
+as_se(exp, assay_name = "abundance")
 }
 \arguments{
 \item{exp}{An \code{\link[=experiment]{experiment()}} object to convert.}
 
 \item{assay_name}{Character string specifying the name for the assay.
-Default is "counts".}
+Default is "abundance".}
 }
 \value{
 A \code{SummarizedExperiment} object.

--- a/tests/testthat/test-se.R
+++ b/tests/testthat/test-se.R
@@ -33,7 +33,7 @@ test_that("as_se converts experiment to SummarizedExperiment correctly", {
   expect_equal(S4Vectors::metadata(se), exp$meta_data)
 
   # Check default assay name
-  expect_equal(names(SummarizedExperiment::assays(se)), "counts")
+  expect_equal(names(SummarizedExperiment::assays(se)), "abundance")
 })
 
 test_that("as_se works with custom assay name", {


### PR DESCRIPTION
## Summary

Updates `as_se()` to name the default `SummarizedExperiment` assay `"abundance"` instead of `"counts"`.

## Background

The old default was inherited from count-style assays, but glycomics and glycoproteomics expression matrices represent abundance data rather than raw counts.

## Details

- Changes the default `assay_name` argument in `as_se()` from `"counts"` to `"abundance"`.
- Updates the generated `as_se()` Rd usage and parameter text.
- Updates the conversion regression test to assert the new default assay name.
- Adds a NEWS entry for the user-visible default change under the development section with the live PR suffix `(#17)`.

## Verification

- `Rscript -e 'devtools::document()'`
- `Rscript -e 'devtools::test(filter = "se")'` passed with 128 expectations, 0 failures, 0 warnings.
- `Rscript -e 'devtools::test()'` passed with 487 expectations, 0 failures, 0 warnings.
- `air format R/se.R tests/testthat/test-se.R`
- `git diff --check`
- `Rscript -e 'devtools::check()'` completed with 0 errors and 0 warnings; it reported 1 NOTE for future file timestamp clock verification in this sandboxed environment.
- After moving the NEWS entry into the development section, `git diff --check` passed again.

Closes #14