### PR TITLE
feat: support GlycoSE inputs in pseudo-glycome and summary helpers

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,7 @@
 
 ## Minor improvements and bug fixes
 
+* `as_pseudo_glycome()` now accepts a `GlycoproteomicSE` object and returns a `GlycomicSE` object.
 * `as_se()` now uses `"abundance"` instead of `"counts"` as the default`SummarizedExperiment` assay name. (#17)
 
 # glyexp 0.14.2

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,7 @@
 
 * `as_pseudo_glycome()` now accepts a `GlycoproteomicSE` object and returns a `GlycomicSE` object.
 * `as_se()` now uses `"abundance"` instead of `"counts"` as the default`SummarizedExperiment` assay name. (#17)
+* `summarize_experiment()` now supports `GlycomicSE` and `GlycoproteomicSE` objects.
 
 # glyexp 0.14.2
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,9 +6,9 @@
 
 ## Minor improvements and bug fixes
 
-* `as_pseudo_glycome()` now accepts a `GlycoproteomicSE` object and returns a `GlycomicSE` object.
+* `as_pseudo_glycome()` now accepts a `GlycoproteomicSE` object and returns a `GlycomicSE` object. (#19)
 * `as_se()` now uses `"abundance"` instead of `"counts"` as the default`SummarizedExperiment` assay name. (#17)
-* `summarize_experiment()` now supports `GlycomicSE` and `GlycoproteomicSE` objects.
+* `summarize_experiment()` now supports `GlycomicSE` and `GlycoproteomicSE` objects. (#19)
 
 # glyexp 0.14.2
 

--- a/R/as-pseudo-glycome.R
+++ b/R/as-pseudo-glycome.R
@@ -205,16 +205,12 @@ as_pseudo_glycome <- function(exp, aggr_method = c("sum", "mean", "median")) {
   group_keys <- as.character(groups)
   group_fac <- factor(group_keys, levels = unique(group_keys))
   row_groups <- split(seq_along(group_keys), group_fac)
-  sample_names <- colnames(expr_mat)
-
-  expr_mat_agg <- purrr::map_dfr(row_groups, function(rows) {
+  expr_rows <- purrr::map(row_groups, function(rows) {
     mat_subset <- expr_mat[rows, , drop = FALSE]
-    result <- .aggregate_pseudo_glycome_rows(mat_subset, aggr_method)
-
-    # Return as a one-row tibble with correct column names
-    tibble::as_tibble_row(stats::setNames(as.list(result), sample_names))
+    .aggregate_pseudo_glycome_rows(mat_subset, aggr_method)
   })
-  expr_mat_agg <- as.matrix(expr_mat_agg)
+  expr_mat_agg <- do.call(rbind, expr_rows)
+  colnames(expr_mat_agg) <- colnames(expr_mat)
   rownames(expr_mat_agg) <- seq_len(nrow(expr_mat_agg))
   expr_mat_agg
 }

--- a/R/as-pseudo-glycome.R
+++ b/R/as-pseudo-glycome.R
@@ -21,14 +21,20 @@
 #' so the aggregation operation is not technically rigorous regardless of the
 #' method used. Use results with caution.
 #'
-#' @param exp A glycoproteomics [experiment()].
+#' @param exp A glycoproteomics [experiment()] or a [GlycoproteomicSE()].
 #' @param aggr_method Aggregation method to use. One of "sum", "mean", or
 #'   "median". Default is "sum". Note that glycopeptides can have different
 #'   ionization efficiencies, so none of these methods are technically rigorous.
 #'
-#' @return A glycomics-type [experiment()] with aggregated expression values.
-#'   The `var_info` will contain only `glycan_composition` and `glycan_structure`
-#'   (if present in input) columns.
+#' @return
+#' If `exp` is an [experiment()], a glycomics-type [experiment()] with
+#' aggregated expression values.
+#'
+#' If `exp` is a [GlycoproteomicSE()], a [GlycomicSE()] with aggregated
+#' expression values.
+#'
+#' The variable metadata will contain only `glycan_composition` and
+#' `glycan_structure` (if present in input) columns.
 #'
 #' @export
 #'
@@ -38,13 +44,29 @@
 #'
 as_pseudo_glycome <- function(exp, aggr_method = c("sum", "mean", "median")) {
   # Validate input
-  if (!is_experiment(exp)) {
-    cli::cli_abort("{.arg exp} must be an experiment.")
+  is_glycoproteomic_se_input <- is_glycoproteomic_se(exp)
+  is_experiment_input <- is_experiment(exp)
+  if (!is_experiment_input && !is_glycoproteomic_se_input) {
+    cli::cli_abort("{.arg exp} must be an experiment or GlycoproteomicSE.")
   }
 
   # Validate and match aggregation method argument
   aggr_method <- rlang::arg_match(aggr_method)
 
+  if (is_glycoproteomic_se_input) {
+    return(.as_pseudo_glycome_glycoproteomic_se(exp, aggr_method))
+  }
+
+  .as_pseudo_glycome_experiment(exp, aggr_method)
+}
+
+#' Convert an experiment to pseudo-glycome
+#'
+#' @param exp A glycoproteomics [experiment()].
+#' @param aggr_method Aggregation method to use.
+#' @returns A glycomics [experiment()].
+#' @noRd
+.as_pseudo_glycome_experiment <- function(exp, aggr_method) {
   exp_type <- get_exp_type(exp)
   if (exp_type != "glycoproteomics") {
     cli::cli_abort(c(
@@ -54,118 +76,211 @@ as_pseudo_glycome <- function(exp, aggr_method = c("sum", "mean", "median")) {
     ))
   }
 
-  # Determine aggregation column
-  if ("glycan_structure" %in% colnames(exp$var_info)) {
-    agg_col <- "glycan_structure"
-  } else {
-    agg_col <- "glycan_composition"
-  }
-
-  # Get unique groups (in order of first appearance)
-  groups <- exp$var_info[[agg_col]]
-  unique_groups <- unique(groups)
-
-  # Handle empty experiment case
-  if (length(unique_groups) == 0) {
-    expr_mat_agg <- matrix(
-      nrow = 0,
-      ncol = ncol(exp$expr_mat),
-      dimnames = list(NULL, colnames(exp$expr_mat))
-    )
-  } else {
-    # Performance optimization for grouping:
-    #
-    # The naive approach would be to use `which(groups == g)` in a loop over
-    # unique_groups. However, this is extremely slow when `groups` is a
-    # glyrepr_structure or glyrepr_composition column because each `==` comparison
-    # involves expensive complex object comparisons (igraph graphs or named vectors).
-    #
-    # For a dataset like real_experiment (4262 variables), this would trigger
-    # ~4262^2/2 expensive comparisons, making the function unusably slow.
-    #
-    # Solution:
-    # 1. Convert to character keys: `as.character(groups)` extracts string
-    #    representations (e.g., "Hex(5)HexNAc(4)" or IUPAC structure strings).
-    #    String comparison is O(1) and much faster than object comparison.
-    #
-    # 2. Use factor with custom levels: `factor(..., levels = unique(group_keys))`
-    #    preserves the order of first appearance. Without this, split() would
-    #    sort the groups alphabetically, changing the result order.
-    #
-    # 3. Use split() on the factor: This groups row indices by their character
-    #    keys in a single pass, avoiding the O(n^2) loop.
-    #
-    # 4. Restore original order: After split(), use match() to reorder
-    #    unique_groups to match the factor level order.
-
-    group_keys <- as.character(groups)
-    group_fac <- factor(group_keys, levels = unique(group_keys))
-
-    # Aggregate expression matrix by summing within each group
-    # Use split() on factor (much faster than which() in loop with glyrepr objects)
-    row_groups <- split(seq_along(group_keys), group_fac)
-    sample_names <- colnames(exp$expr_mat)
-
-    # Use map_dfr to aggregate each group, ensuring consistent column structure
-    expr_mat_agg <- purrr::map_dfr(row_groups, function(rows) {
-      mat_subset <- exp$expr_mat[rows, , drop = FALSE]
-
-      if (length(rows) == 1) {
-        # Single row: just use it directly as a named vector
-        result <- mat_subset[1, , drop = TRUE]
-      } else {
-        # Multiple rows: apply aggregation method
-        # First, identify columns where all values are NA (should result in NA, not 0)
-        all_na_cols <- apply(mat_subset, 2, function(x) all(is.na(x)))
-
-        result <- switch(
-          aggr_method,
-          sum = colSums(mat_subset, na.rm = TRUE),
-          mean = colMeans(mat_subset, na.rm = TRUE),
-          median = apply(mat_subset, 2, stats::median, na.rm = TRUE)
-        )
-
-        # For columns where all values were NA, force result to NA
-        # (sum returns 0, mean returns NaN for all-NA with na.rm=TRUE)
-        result[all_na_cols] <- NA_real_
-      }
-      # Return as a one-row tibble with correct column names
-      tibble::as_tibble_row(stats::setNames(as.list(result), sample_names))
-    })
-    expr_mat_agg <- as.matrix(expr_mat_agg)
-    rownames(expr_mat_agg) <- seq_len(nrow(expr_mat_agg))
-
-    # Reorder unique_groups to match the order of row_groups
-    unique_groups <- unique_groups[match(
-      names(row_groups),
-      as.character(unique_groups)
-    )]
-  }
-
-  # Build new var_info with only essential glycan columns
-  var_info_new <- tibble::tibble(
-    variable = as.character(seq_len(length(unique_groups)))
+  pseudo_glycome <- .pseudo_glycome_data(
+    expr_mat = exp$expr_mat,
+    var_info = exp$var_info,
+    aggr_method = aggr_method
   )
-
-  # Add aggregation column
-  if (agg_col == "glycan_structure") {
-    var_info_new$glycan_structure <- unique_groups
-    var_info_new$glycan_composition <- glyrepr::as_glycan_composition(
-      unique_groups
-    )
-  } else {
-    var_info_new$glycan_composition <- unique_groups
-  }
 
   # Create new experiment
   result <- experiment(
-    expr_mat = expr_mat_agg,
+    expr_mat = pseudo_glycome$expr_mat,
     sample_info = exp$sample_info,
-    var_info = var_info_new,
+    var_info = pseudo_glycome$var_info,
     exp_type = "glycomics",
     glycan_type = exp$meta_data$glycan_type
   )
 
   # Standardize variable IDs
   standardize_variable(result)
+}
+
+#' Convert a GlycoproteomicSE to pseudo-glycome
+#'
+#' @param exp A [GlycoproteomicSE()].
+#' @param aggr_method Aggregation method to use.
+#' @returns A [GlycomicSE()].
+#' @noRd
+.as_pseudo_glycome_glycoproteomic_se <- function(exp, aggr_method) {
+  .require_se()
+
+  pseudo_glycome <- .pseudo_glycome_data(
+    expr_mat = SummarizedExperiment::assay(exp, 1),
+    var_info = SummarizedExperiment::rowData(exp),
+    aggr_method = aggr_method
+  )
+  meta_data <- S4Vectors::metadata(exp)
+  meta_data$exp_type <- "glycomics"
+
+  GlycomicSE(
+    abundance = pseudo_glycome$expr_mat,
+    colData = SummarizedExperiment::colData(exp),
+    rowData = .pseudo_glycome_row_data(pseudo_glycome$var_info),
+    metadata = meta_data
+  )
+}
+
+#' Build pseudo-glycome abundance and variable metadata
+#'
+#' @param expr_mat A numeric abundance matrix.
+#' @param var_info Variable metadata with glycan columns.
+#' @param aggr_method Aggregation method to use.
+#' @returns A list with `expr_mat` and `var_info`.
+#' @noRd
+.pseudo_glycome_data <- function(expr_mat, var_info, aggr_method) {
+  # Determine aggregation column
+  if ("glycan_structure" %in% colnames(var_info)) {
+    agg_col <- "glycan_structure"
+  } else {
+    agg_col <- "glycan_composition"
+  }
+
+  # Get unique groups (in order of first appearance)
+  groups <- var_info[[agg_col]]
+  unique_groups <- unique(groups)
+  expr_mat_agg <- .aggregate_pseudo_glycome_expr_mat(
+    expr_mat = expr_mat,
+    groups = groups,
+    unique_groups = unique_groups,
+    aggr_method = aggr_method
+  )
+
+  list(
+    expr_mat = expr_mat_agg,
+    var_info = .pseudo_glycome_var_info(
+      unique_groups = unique_groups,
+      agg_col = agg_col
+    )
+  )
+}
+
+#' Aggregate an expression matrix by glycan group
+#'
+#' @param expr_mat A numeric abundance matrix.
+#' @param groups Glycan groups, one per matrix row.
+#' @param unique_groups Unique glycan groups.
+#' @param aggr_method Aggregation method to use.
+#' @returns An aggregated abundance matrix.
+#' @noRd
+.aggregate_pseudo_glycome_expr_mat <- function(
+  expr_mat,
+  groups,
+  unique_groups,
+  aggr_method
+) {
+  # Handle empty experiment case
+  if (length(unique_groups) == 0) {
+    return(matrix(
+      nrow = 0,
+      ncol = ncol(expr_mat),
+      dimnames = list(NULL, colnames(expr_mat))
+    ))
+  }
+
+  # Performance optimization for grouping:
+  #
+  # The naive approach would be to use `which(groups == g)` in a loop over
+  # unique_groups. However, this is extremely slow when `groups` is a
+  # glyrepr_structure or glyrepr_composition column because each `==` comparison
+  # involves expensive complex object comparisons (igraph graphs or named vectors).
+  #
+  # For a dataset like real_experiment (4262 variables), this would trigger
+  # ~4262^2/2 expensive comparisons, making the function unusably slow.
+  #
+  # Solution:
+  # 1. Convert to character keys: `as.character(groups)` extracts string
+  #    representations (e.g., "Hex(5)HexNAc(4)" or IUPAC structure strings).
+  #    String comparison is O(1) and much faster than object comparison.
+  #
+  # 2. Use factor with custom levels: `factor(..., levels = unique(group_keys))`
+  #    preserves the order of first appearance. Without this, split() would
+  #    sort the groups alphabetically, changing the result order.
+  #
+  # 3. Use split() on the factor: This groups row indices by their character
+  #    keys in a single pass, avoiding the O(n^2) loop.
+  #
+  # 4. The variable metadata is built from `unique_groups`, which preserves
+  #    the same first-appearance order used by the factor levels.
+
+  group_keys <- as.character(groups)
+  group_fac <- factor(group_keys, levels = unique(group_keys))
+  row_groups <- split(seq_along(group_keys), group_fac)
+  sample_names <- colnames(expr_mat)
+
+  expr_mat_agg <- purrr::map_dfr(row_groups, function(rows) {
+    mat_subset <- expr_mat[rows, , drop = FALSE]
+    result <- .aggregate_pseudo_glycome_rows(mat_subset, aggr_method)
+
+    # Return as a one-row tibble with correct column names
+    tibble::as_tibble_row(stats::setNames(as.list(result), sample_names))
+  })
+  expr_mat_agg <- as.matrix(expr_mat_agg)
+  rownames(expr_mat_agg) <- seq_len(nrow(expr_mat_agg))
+  expr_mat_agg
+}
+
+#' Aggregate rows for one pseudo-glycome group
+#'
+#' @param mat_subset A matrix containing one glycan group.
+#' @param aggr_method Aggregation method to use.
+#' @returns A named numeric vector with one value per sample.
+#' @noRd
+.aggregate_pseudo_glycome_rows <- function(mat_subset, aggr_method) {
+  if (nrow(mat_subset) == 1) {
+    return(mat_subset[1, , drop = TRUE])
+  }
+
+  # Columns where all values are NA should return NA, not 0 or NaN.
+  all_na_cols <- purrr::map_lgl(seq_len(ncol(mat_subset)), function(col) {
+    all(is.na(mat_subset[, col]))
+  })
+
+  result <- switch(
+    aggr_method,
+    sum = colSums(mat_subset, na.rm = TRUE),
+    mean = colMeans(mat_subset, na.rm = TRUE),
+    median = purrr::map_dbl(seq_len(ncol(mat_subset)), function(col) {
+      stats::median(mat_subset[, col], na.rm = TRUE)
+    })
+  )
+  names(result) <- colnames(mat_subset)
+
+  # For columns where all values were NA, force result to NA.
+  result[all_na_cols] <- NA_real_
+  result
+}
+
+#' Build pseudo-glycome variable metadata
+#'
+#' @param unique_groups Unique glycan groups.
+#' @param agg_col Aggregation column name.
+#' @returns A tibble with pseudo-glycome variable metadata.
+#' @noRd
+.pseudo_glycome_var_info <- function(unique_groups, agg_col) {
+  var_info <- tibble::tibble(
+    variable = as.character(seq_len(length(unique_groups)))
+  )
+
+  # Add aggregation column
+  if (agg_col == "glycan_structure") {
+    var_info$glycan_structure <- unique_groups
+    var_info$glycan_composition <- glyrepr::as_glycan_composition(
+      unique_groups
+    )
+  } else {
+    var_info$glycan_composition <- unique_groups
+  }
+
+  var_info
+}
+
+#' Convert pseudo-glycome variable metadata to rowData
+#'
+#' @param var_info Pseudo-glycome variable metadata.
+#' @returns An `S4Vectors::DataFrame()`.
+#' @noRd
+.pseudo_glycome_row_data <- function(var_info) {
+  row_names <- var_info$variable
+  row_data <- var_info[setdiff(colnames(var_info), "variable")]
+  S4Vectors::DataFrame(row_data, row.names = row_names)
 }

--- a/R/summarize.R
+++ b/R/summarize.R
@@ -75,12 +75,25 @@ summarize_experiment <- function(x, count_struct = NULL) {
 
   if (is_glycomic_se(x) || is_glycoproteomic_se(x)) {
     .require_se()
+    expr_mat <- SummarizedExperiment::assay(x, 1)
+    row_data <- SummarizedExperiment::rowData(x)
+    col_data <- SummarizedExperiment::colData(x)
+    expr_mat <- .summarize_se_assay_with_dimnames(
+      expr_mat = expr_mat,
+      row_data = row_data,
+      col_data = col_data
+    )
+    var_info <- tibble::as_tibble(row_data)
+    var_info$variable <- NULL
+    var_info <- tibble::add_column(
+      var_info,
+      variable = rownames(expr_mat),
+      .before = 1
+    )
+
     return(list(
-      expr_mat = SummarizedExperiment::assay(x, 1),
-      var_info = tibble::as_tibble(
-        SummarizedExperiment::rowData(x),
-        rownames = "variable"
-      ),
+      expr_mat = expr_mat,
+      var_info = var_info,
       is_gp = is_glycoproteomic_se(x)
     ))
   }
@@ -88,6 +101,35 @@ summarize_experiment <- function(x, count_struct = NULL) {
   cli::cli_abort(
     "{.arg x} must be an experiment, GlycomicSE, or GlycoproteomicSE."
   )
+}
+
+#' Normalize SE assay dimnames for summarization
+#'
+#' @param expr_mat A numeric expression matrix.
+#' @param row_data The `rowData`.
+#' @param col_data The `colData`.
+#' @returns The expression matrix with row and column names.
+#' @noRd
+.summarize_se_assay_with_dimnames <- function(expr_mat, row_data, col_data) {
+  row_names <- rownames(expr_mat)
+  if (is.null(row_names) || length(row_names) != nrow(expr_mat)) {
+    row_names <- rownames(row_data)
+  }
+  if (is.null(row_names) || length(row_names) != nrow(expr_mat)) {
+    row_names <- as.character(seq_len(nrow(expr_mat)))
+  }
+
+  col_names <- colnames(expr_mat)
+  if (is.null(col_names) || length(col_names) != ncol(expr_mat)) {
+    col_names <- rownames(col_data)
+  }
+  if (is.null(col_names) || length(col_names) != ncol(expr_mat)) {
+    col_names <- as.character(seq_len(ncol(expr_mat)))
+  }
+
+  rownames(expr_mat) <- row_names
+  colnames(expr_mat) <- col_names
+  expr_mat
 }
 
 #' Summarize extracted experiment data

--- a/R/summarize.R
+++ b/R/summarize.R
@@ -2,7 +2,8 @@
 #'
 #' This function summarizes the number of
 #' glycan compositions, glycan structures, glycopeptides, peptides,
-#' glycoforms, glycoproteins, and glycosites in an [experiment()].
+#' glycoforms, glycoproteins, and glycosites in an [experiment()],
+#' [GlycomicSE()], or [GlycoproteomicSE()].
 #'
 #' @details
 #' The following columns are required in the variable information tibble:
@@ -18,7 +19,7 @@
 #' You can use `count_struct` parameter to control how to count glycopeptides and glycoforms,
 #' either by glycan structures or by glycan compositions.
 #'
-#' @param x An [experiment()] object.
+#' @param x An [experiment()], [GlycomicSE()], or [GlycoproteomicSE()] object.
 #' @param count_struct For counting glycopeptides and glycoforms.
 #' whether to count the number of glycan structures or glycopeptides.
 #' If `TRUE`, glycopeptides or glycoforms bearing different glycan structures
@@ -47,10 +48,63 @@
 #'
 #' @export
 summarize_experiment <- function(x, count_struct = NULL) {
-  checkmate::assert_class(x, "glyexp_experiment")
   checkmate::assert_flag(count_struct, null.ok = TRUE)
 
-  has_struct <- "glycan_structure" %in% colnames(x$var_info)
+  data <- .summarize_experiment_data(x)
+  .summarize_experiment_impl(
+    expr_mat = data$expr_mat,
+    var_info = data$var_info,
+    is_gp = data$is_gp,
+    count_struct = count_struct
+  )
+}
+
+#' Extract summarizer inputs from supported containers
+#'
+#' @param x An object to summarize.
+#' @returns A list with `expr_mat`, `var_info`, and `is_gp`.
+#' @noRd
+.summarize_experiment_data <- function(x) {
+  if (is_experiment(x)) {
+    return(list(
+      expr_mat = x$expr_mat,
+      var_info = x$var_info,
+      is_gp = get_exp_type(x) == "glycoproteomics"
+    ))
+  }
+
+  if (is_glycomic_se(x) || is_glycoproteomic_se(x)) {
+    .require_se()
+    return(list(
+      expr_mat = SummarizedExperiment::assay(x, 1),
+      var_info = tibble::as_tibble(
+        SummarizedExperiment::rowData(x),
+        rownames = "variable"
+      ),
+      is_gp = is_glycoproteomic_se(x)
+    ))
+  }
+
+  cli::cli_abort(
+    "{.arg x} must be an experiment, GlycomicSE, or GlycoproteomicSE."
+  )
+}
+
+#' Summarize extracted experiment data
+#'
+#' @param expr_mat A numeric expression matrix.
+#' @param var_info Variable metadata.
+#' @param is_gp Whether the input is glycoproteomics data.
+#' @param count_struct Whether to count structure-level glycoforms.
+#' @returns A summary tibble.
+#' @noRd
+.summarize_experiment_impl <- function(
+  expr_mat,
+  var_info,
+  is_gp,
+  count_struct
+) {
+  has_struct <- "glycan_structure" %in% colnames(var_info)
   if (is.null(count_struct)) {
     count_struct <- has_struct
   } else if (count_struct && !has_struct) {
@@ -61,7 +115,6 @@ summarize_experiment <- function(x, count_struct = NULL) {
   }
 
   glycan_col <- if (count_struct) "glycan_structure" else "glycan_composition"
-  is_gp <- get_exp_type(x) == "glycoproteomics"
 
   items <- list(
     composition = list(cols = "glycan_composition", gp = FALSE),
@@ -87,11 +140,11 @@ summarize_experiment <- function(x, count_struct = NULL) {
     if ("glycan_structure" %in% def$cols && !count_struct) {
       return(NULL)
     }
-    if (!all(def$cols %in% colnames(x$var_info))) {
+    if (!all(def$cols %in% colnames(var_info))) {
       return(NULL)
     }
 
-    dplyr::n_distinct(x$var_info[, def$cols, drop = FALSE])
+    dplyr::n_distinct(var_info[, def$cols, drop = FALSE])
   })
   names(total_counts) <- paste0("total_", names(total_counts))
 
@@ -103,21 +156,21 @@ summarize_experiment <- function(x, count_struct = NULL) {
     if ("glycan_structure" %in% def$cols && !count_struct) {
       return(NULL)
     }
-    if (!all(def$cols %in% colnames(x$var_info))) {
+    if (!all(def$cols %in% colnames(var_info))) {
       return(NULL)
     }
 
     # For each sample, count unique items with non-NA values
-    sample_counts <- purrr::map_int(colnames(x$expr_mat), function(s) {
+    sample_counts <- purrr::map_int(colnames(expr_mat), function(s) {
       # Get variables detected in this sample
-      detected_vars <- rownames(x$expr_mat)[!is.na(x$expr_mat[, s])]
+      detected_vars <- rownames(expr_mat)[!is.na(expr_mat[, s])]
       if (length(detected_vars) == 0) {
         return(0L)
       }
 
       # Filter var_info for these variables
-      var_subset <- x$var_info[
-        match(detected_vars, x$var_info$variable),
+      var_subset <- var_info[
+        match(detected_vars, var_info$variable),
         ,
         drop = FALSE
       ]

--- a/man/as_pseudo_glycome.Rd
+++ b/man/as_pseudo_glycome.Rd
@@ -7,16 +7,21 @@
 as_pseudo_glycome(exp, aggr_method = c("sum", "mean", "median"))
 }
 \arguments{
-\item{exp}{A glycoproteomics \code{\link[=experiment]{experiment()}}.}
+\item{exp}{A glycoproteomics \code{\link[=experiment]{experiment()}} or a \code{\link[=GlycoproteomicSE]{GlycoproteomicSE()}}.}
 
 \item{aggr_method}{Aggregation method to use. One of "sum", "mean", or
 "median". Default is "sum". Note that glycopeptides can have different
 ionization efficiencies, so none of these methods are technically rigorous.}
 }
 \value{
-A glycomics-type \code{\link[=experiment]{experiment()}} with aggregated expression values.
-The \code{var_info} will contain only \code{glycan_composition} and \code{glycan_structure}
-(if present in input) columns.
+If \code{exp} is an \code{\link[=experiment]{experiment()}}, a glycomics-type \code{\link[=experiment]{experiment()}} with
+aggregated expression values.
+
+If \code{exp} is a \code{\link[=GlycoproteomicSE]{GlycoproteomicSE()}}, a \code{\link[=GlycomicSE]{GlycomicSE()}} with aggregated
+expression values.
+
+The variable metadata will contain only \code{glycan_composition} and
+\code{glycan_structure} (if present in input) columns.
 }
 \description{
 Transforms a glycoproteomics-type experiment into a glycomics-type experiment

--- a/man/summarize_experiment.Rd
+++ b/man/summarize_experiment.Rd
@@ -7,7 +7,7 @@
 summarize_experiment(x, count_struct = NULL)
 }
 \arguments{
-\item{x}{An \code{\link[=experiment]{experiment()}} object.}
+\item{x}{An \code{\link[=experiment]{experiment()}}, \code{\link[=GlycomicSE]{GlycomicSE()}}, or \code{\link[=GlycoproteomicSE]{GlycoproteomicSE()}} object.}
 
 \item{count_struct}{For counting glycopeptides and glycoforms.
 whether to count the number of glycan structures or glycopeptides.
@@ -35,7 +35,8 @@ For example, \code{composition_per_sample} is the average number of glycan compo
 \description{
 This function summarizes the number of
 glycan compositions, glycan structures, glycopeptides, peptides,
-glycoforms, glycoproteins, and glycosites in an \code{\link[=experiment]{experiment()}}.
+glycoforms, glycoproteins, and glycosites in an \code{\link[=experiment]{experiment()}},
+\code{\link[=GlycomicSE]{GlycomicSE()}}, or \code{\link[=GlycoproteomicSE]{GlycoproteomicSE()}}.
 }
 \details{
 The following columns are required in the variable information tibble:

--- a/tests/testthat/test-as-pseudo-glycome.R
+++ b/tests/testthat/test-as-pseudo-glycome.R
@@ -43,6 +43,42 @@ create_test_gp_exp <- function() {
   )
 }
 
+create_test_gp_se <- function() {
+  expr_mat <- matrix(
+    c(1, 4, 7, 10, 2, 5, 8, 11, 3, 6, 9, 12),
+    nrow = 4,
+    ncol = 3,
+    dimnames = list(
+      c("GP1", "GP2", "GP3", "GP4"),
+      c("S1", "S2", "S3")
+    )
+  )
+
+  col_data <- S4Vectors::DataFrame(
+    group = factor(c("A", "A", "B")),
+    row.names = c("S1", "S2", "S3")
+  )
+
+  row_data <- S4Vectors::DataFrame(
+    protein = c("P1", "P1", "P2", "P2"),
+    protein_site = c(1L, 2L, 1L, 2L),
+    glycan_composition = glyrepr::as_glycan_composition(c(
+      "H5N4",
+      "H5N4",
+      "H6N5",
+      "H6N5"
+    )),
+    row.names = c("GP1", "GP2", "GP3", "GP4")
+  )
+
+  GlycoproteomicSE(
+    abundance = expr_mat,
+    colData = col_data,
+    rowData = row_data,
+    metadata = list(glycan_type = "N", source = "direct-se")
+  )
+}
+
 test_that("as_pseudo_glycome aggregates by glycan_composition", {
   gp_exp <- create_test_gp_exp()
 
@@ -71,6 +107,37 @@ test_that("as_pseudo_glycome aggregates by glycan_composition", {
   # Should not have protein columns
   expect_false("protein" %in% colnames(result$var_info))
   expect_false("protein_site" %in% colnames(result$var_info))
+})
+
+test_that("as_pseudo_glycome accepts GlycoproteomicSE and returns GlycomicSE", {
+  gp_se <- create_test_gp_se()
+  expect_null(S4Vectors::metadata(gp_se)$exp_type)
+
+  result <- as_pseudo_glycome(gp_se)
+
+  expect_s4_class(result, "GlycomicSE")
+  expect_false(glyexp::is_experiment(result))
+
+  expected_abundance <- matrix(
+    c(5, 17, 7, 19, 9, 21),
+    nrow = 2,
+    dimnames = list(c("1", "2"), c("S1", "S2", "S3"))
+  )
+  expect_equal(SummarizedExperiment::assay(result), expected_abundance)
+
+  row_data <- SummarizedExperiment::rowData(result)
+  expect_equal(rownames(row_data), c("1", "2"))
+  expect_true("glycan_composition" %in% colnames(row_data))
+  expect_false("protein" %in% colnames(row_data))
+  expect_false("protein_site" %in% colnames(row_data))
+
+  col_data <- SummarizedExperiment::colData(result)
+  expect_equal(col_data$group, factor(c("A", "A", "B")))
+
+  meta_data <- S4Vectors::metadata(result)
+  expect_equal(meta_data$glycan_type, "N")
+  expect_equal(meta_data$exp_type, "glycomics")
+  expect_equal(meta_data$source, "direct-se")
 })
 
 

--- a/tests/testthat/test-as-pseudo-glycome.R
+++ b/tests/testthat/test-as-pseudo-glycome.R
@@ -140,6 +140,28 @@ test_that("as_pseudo_glycome accepts GlycoproteomicSE and returns GlycomicSE", {
   expect_equal(meta_data$source, "direct-se")
 })
 
+test_that("as_pseudo_glycome handles GlycoproteomicSE without assay dimnames", {
+  abundance <- matrix(c(1, 4, 2, 5), nrow = 2, ncol = 2)
+  row_data <- S4Vectors::DataFrame(
+    protein = c("P1", "P2"),
+    protein_site = c(1L, 2L),
+    glycan_composition = glyrepr::as_glycan_composition(c("H5N4", "H5N4"))
+  )
+  gp_se <- GlycoproteomicSE(
+    abundance = abundance,
+    rowData = row_data,
+    metadata = list(glycan_type = "N")
+  )
+
+  result <- as_pseudo_glycome(gp_se)
+
+  expect_s4_class(result, "GlycomicSE")
+  expect_equal(
+    SummarizedExperiment::assay(result),
+    matrix(c(5, 7), nrow = 1, ncol = 2, dimnames = list("1", NULL))
+  )
+})
+
 
 test_that("as_pseudo_glycome preserves correct matrix dimensions with complex row names", {
   # This test ensures that aggregation works correctly when row names are complex

--- a/tests/testthat/test-summarize.R
+++ b/tests/testthat/test-summarize.R
@@ -198,3 +198,67 @@ test_that("summarize_experiment calculates per_sample stats correctly", {
   # Average Protein: (2 + 1) / 2 = 1.5
   expect_equal(res$n[res$item == "protein_per_sample"], 1.5)
 })
+
+test_that("summarize_experiment works for GlycomicSE", {
+  abundance <- matrix(
+    c(10, NA, 20, 30, 40, NA),
+    nrow = 3,
+    ncol = 2,
+    dimnames = list(c("G1", "G2", "G3"), c("S1", "S2"))
+  )
+  row_data <- S4Vectors::DataFrame(
+    glycan_composition = glyrepr::as_glycan_composition(c(
+      "H5N2",
+      "H6N3",
+      "H5N2"
+    )),
+    row.names = rownames(abundance)
+  )
+  se <- GlycomicSE(
+    abundance,
+    rowData = row_data,
+    metadata = list(glycan_type = "N")
+  )
+
+  res <- summarize_experiment(se)
+
+  expect_equal(res$n[res$item == "total_composition"], 2)
+  expect_equal(res$n[res$item == "composition_per_sample"], 1.5)
+  expect_false("total_protein" %in% res$item)
+})
+
+test_that("summarize_experiment works for GlycoproteomicSE", {
+  abundance <- matrix(
+    c(10, NA, 20, 30, 40, NA),
+    nrow = 3,
+    ncol = 2,
+    dimnames = list(c("GP1", "GP2", "GP3"), c("S1", "S2"))
+  )
+  row_data <- S4Vectors::DataFrame(
+    protein = c("P1", "P1", "P2"),
+    protein_site = c(1L, 1L, 2L),
+    peptide = c("PEP1", "PEP1", "PEP2"),
+    peptide_site = c("N1", "N1", "N2"),
+    glycan_composition = glyrepr::as_glycan_composition(c(
+      "H5N2",
+      "H5N2",
+      "H6N3"
+    )),
+    row.names = rownames(abundance)
+  )
+  se <- GlycoproteomicSE(
+    abundance,
+    rowData = row_data,
+    metadata = list(glycan_type = "N")
+  )
+
+  res <- summarize_experiment(se)
+
+  expect_equal(res$n[res$item == "total_composition"], 2)
+  expect_equal(res$n[res$item == "total_glycopeptide"], 2)
+  expect_equal(res$n[res$item == "total_glycoform"], 2)
+  expect_equal(res$n[res$item == "total_protein"], 2)
+  expect_equal(res$n[res$item == "total_glycosite"], 2)
+  expect_equal(res$n[res$item == "composition_per_sample"], 1.5)
+  expect_equal(res$n[res$item == "protein_per_sample"], 1.5)
+})

--- a/tests/testthat/test-summarize.R
+++ b/tests/testthat/test-summarize.R
@@ -227,6 +227,27 @@ test_that("summarize_experiment works for GlycomicSE", {
   expect_false("total_protein" %in% res$item)
 })
 
+test_that("summarize_experiment uses positions for SE inputs without assay dimnames", {
+  abundance <- matrix(c(10, NA, 20, 30, 40, NA), nrow = 3, ncol = 2)
+  row_data <- S4Vectors::DataFrame(
+    glycan_composition = glyrepr::as_glycan_composition(c(
+      "H5N2",
+      "H6N3",
+      "H5N2"
+    ))
+  )
+  se <- GlycomicSE(
+    abundance,
+    rowData = row_data,
+    metadata = list(glycan_type = "N")
+  )
+
+  res <- summarize_experiment(se)
+
+  expect_equal(res$n[res$item == "total_composition"], 2)
+  expect_equal(res$n[res$item == "composition_per_sample"], 1.5)
+})
+
 test_that("summarize_experiment works for GlycoproteomicSE", {
   abundance <- matrix(
     c(10, NA, 20, 30, 40, NA),


### PR DESCRIPTION
## Summary

- Add direct `GlycoproteomicSE` support to `as_pseudo_glycome()`, returning a `GlycomicSE` while preserving existing `experiment()` support.
- Add `GlycomicSE` and `GlycoproteomicSE` support to `summarize_experiment()`.
- Handle valid GlycoSE inputs whose abundance assays do not define row or column names.

## Details

- Split pseudo-glycome conversion into container-specific entry paths plus shared aggregation helpers.
- Read `GlycoproteomicSE` data directly from `assay()`, `rowData()`, `colData()`, and `metadata()` instead of routing through `experiment()`.
- Aggregate pseudo-glycome matrices without requiring assay column names.
- Normalize SE assay row and column names to rowData/colData names or positional IDs before reusing the `summarize_experiment()` counting logic.
- Add regression tests for direct SE subclass inputs, including unnamed assay dimnames, and refresh Rd documentation.

## Verification

- `Rscript -e 'devtools::load_all(); devtools::test(filter = "as-pseudo-glycome")'` -> 63 passed, 0 failed, 0 warnings.
- `Rscript -e 'devtools::load_all(); devtools::test(filter = "summarize")'` -> 39 passed, 0 failed, 0 warnings.
- `Rscript -e 'devtools::load_all(); devtools::test()'` -> 561 passed, 0 failed, 0 warnings.
- `Rscript -e 'devtools::check(error_on = "warning")'` -> 0 errors, 0 warnings, 1 NOTE for remote system-clock verification in the sandbox.
- `git diff --check` -> clean.