### PR TITLE
fix: accept broader glycan_type values

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,7 @@
 
 * `as_pseudo_glycome()` now accepts a `GlycoproteomicSE` object and returns a `GlycomicSE` object. (#19)
 * `as_se()` now uses `"abundance"` instead of `"counts"` as the default`SummarizedExperiment` assay name. (#17)
+* `glycan_type` validation now accepts `"O"`, `"HMO"`, `"GSL"`, `"GAG"`, and `"GPI"`.
 * `summarize_experiment()` now supports `GlycomicSE` and `GlycoproteomicSE` objects. (#19)
 
 # glyexp 0.14.2

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,7 +8,7 @@
 
 * `as_pseudo_glycome()` now accepts a `GlycoproteomicSE` object and returns a `GlycomicSE` object. (#19)
 * `as_se()` now uses `"abundance"` instead of `"counts"` as the default`SummarizedExperiment` assay name. (#17)
-* `glycan_type` validation now accepts `"O"`, `"HMO"`, `"GSL"`, `"GAG"`, and `"GPI"`.
+* `glycan_type` validation now accepts `"O"`, `"HMO"`, `"GSL"`, `"GAG"`, and `"GPI"`. (#20)
 * `summarize_experiment()` now supports `GlycomicSE` and `GlycoproteomicSE` objects. (#19)
 
 # glyexp 0.14.2

--- a/R/experiment.R
+++ b/R/experiment.R
@@ -73,7 +73,8 @@
 #' Two meta data fields are required:
 #'
 #' - `exp_type`: "glycomics", "glycoproteomics", "traitomics", "traitproteomics", or "others"
-#' - `glycan_type`: "N", "O-GalNAc", "O-GlcNAc", "O-Man", "O-Fuc", "O-Glc", or NULL
+#' - `glycan_type`: "N", "O", "O-GalNAc", "O-Man", "O-Fuc",
+#'   "O-GlcNAc", "O-Glc", "HMO", "GSL", "GAG", "GPI", or NULL
 #'
 #' Other meta data will be added by other `glycoverse` packages for their own purposes.
 #'
@@ -214,6 +215,34 @@ is_experiment <- function(x) {
 }
 
 
+#' Valid glycan type values
+#'
+#' @returns A character vector of valid `glycan_type` values.
+#' @noRd
+.valid_glycan_types <- function() {
+  c(
+    "N",
+    "O",
+    "O-GalNAc",
+    "O-Man",
+    "O-Fuc",
+    "O-GlcNAc",
+    "O-Glc",
+    "HMO",
+    "GSL",
+    "GAG",
+    "GPI"
+  )
+}
+
+#' Format valid glycan type values for messages
+#'
+#' @returns A string containing quoted valid `glycan_type` values.
+#' @noRd
+.format_glycan_type_choices <- function() {
+  glue::glue_collapse(glue::glue("\"{.valid_glycan_types()}\""), sep = ", ")
+}
+
 .check_meta_data <- function(meta_data) {
   exp_type <- meta_data$exp_type
   glycan_type <- meta_data$glycan_type
@@ -237,12 +266,13 @@ is_experiment <- function(x) {
   if (
     !checkmate::test_choice(
       glycan_type,
-      c("N", "O-GalNAc", "O-GlcNAc", "O-Man", "O-Fuc", "O-Glc"),
+      .valid_glycan_types(),
       null.ok = TRUE
     )
   ) {
+    valid_glycan_type_choices <- .format_glycan_type_choices()
     cli::cli_abort(c(
-      "{.arg glycan_type} must be one of {.val N}, {.val O-GalNAc}, {.val O-GlcNAc}, {.val O-Man}, {.val O-Fuc}, or {.val O-Glc}.",
+      "{.arg glycan_type} must be one of {valid_glycan_type_choices}.",
       "x" = "Got {.val {glycan_type}}."
     ))
   }

--- a/R/experiment.R
+++ b/R/experiment.R
@@ -105,7 +105,7 @@
 #'   "glycomics", "glycoproteomics", "traitomics", "traitproteomics", or "others".
 #'   Default to "others".
 #' @param glycan_type The type of glycan.
-#'   One of "N", "O-GalNAc", "O-GlcNAc", "O-Man", "O-Fuc", "O-Glc".
+#'   One of the valid `glycan_type` values listed in the metadata details.
 #'   Can also be NULL if `exp_type` is "others".
 #' @param coerce_col_types If common column types are coerced. Default to TRUE.
 #'   If TRUE, all columns in the "Column conventions" section will be coerced to the expected types.

--- a/R/glyco-se.R
+++ b/R/glyco-se.R
@@ -39,7 +39,8 @@
 #'     - `glycan_structure`: optional, a `glyrepr::glycan_structure()` vector
 #'   - `colData`: A `S4Vectors::DataFrame()`.
 #'   - `metadata`: A list. It must include a `glycan_type` field with one of
-#'     `"N"`, `"O-GalNAc"`, `"O-GlcNAc"`, `"O-Man"`, `"O-Fuc"`, or `"O-Glc"`.
+#'     `"N"`, `"O"`, `"O-GalNAc"`, `"O-Man"`, `"O-Fuc"`, `"O-GlcNAc"`,
+#'     `"O-Glc"`, `"HMO"`, `"GSL"`, `"GAG"`, or `"GPI"`.
 #'
 #' @returns A `GlycomicSE` object.
 #' @aliases GlycomicSE-class
@@ -129,7 +130,8 @@ is_glycomic_se <- function(x) {
 #'     - `glycan_structure`: optional, a `glyrepr::glycan_structure()` vector
 #'   - `colData`: A `S4Vectors::DataFrame()`.
 #'   - `metadata`: A list. It must include a `glycan_type` field with one of
-#'     `"N"`, `"O-GalNAc"`, `"O-GlcNAc"`, `"O-Man"`, `"O-Fuc"`, or `"O-Glc"`.
+#'     `"N"`, `"O"`, `"O-GalNAc"`, `"O-Man"`, `"O-Fuc"`, `"O-GlcNAc"`,
+#'     `"O-Glc"`, `"HMO"`, `"GSL"`, `"GAG"`, or `"GPI"`.
 #' @returns A `GlycoproteomicSE` object.
 #' @aliases GlycoproteomicSE-class
 #' @section S4 class:
@@ -236,7 +238,7 @@ S4Vectors::setValidity2("GlycoproteomicSE", function(object) {
   if (is.null(glycan_type)) {
     return("metadata `glycan_type` must be provided")
   }
-  choices <- c("N", "O-GalNAc", "O-GlcNAc", "O-Man", "O-Fuc", "O-Glc")
+  choices <- .valid_glycan_types()
   if (glycan_type %in% choices) {
     NULL
   } else {

--- a/R/meta-data.R
+++ b/R/meta-data.R
@@ -2,7 +2,8 @@
 #'
 #' Meta data is some descriptions about the experiment,
 #' like the experiment type ("glycomics" or "glycoproteomics"),
-#' or the glycan type ("N", "O-GalNAc", "O-GlcNAc", "O-Man", "O-Fuc", or "O-Glc").
+#' or the glycan type ("N", "O", "O-GalNAc", "O-Man", "O-Fuc",
+#' "O-GlcNAc", "O-Glc", "HMO", "GSL", "GAG", or "GPI").
 #'
 #' @param exp An [experiment()].
 #' @param x A string, the name of the meta data field.
@@ -43,7 +44,8 @@ get_glycan_type <- function(exp) {
 #'
 #' Set meta data values for the experiment,
 #' like the experiment type ("glycomics" or "glycoproteomics"),
-#' or the glycan type ("N", "O-GalNAc", "O-GlcNAc", "O-Man", "O-Fuc", or "O-Glc").
+#' or the glycan type ("N", "O", "O-GalNAc", "O-Man", "O-Fuc",
+#' "O-GlcNAc", "O-Glc", "HMO", "GSL", "GAG", or "GPI").
 #'
 #' @param exp An [experiment()].
 #' @param x A string,

--- a/R/se.R
+++ b/R/se.R
@@ -79,7 +79,7 @@ as_se <- function(exp, assay_name = "abundance") {
 #'   If not supplied, will try to extract from metadata.
 #'   If unavailable there, an error is issued.
 #' @param glycan_type Character string specifying glycan type.
-#'   Must be either "N", "O-GalNAc", "O-GlcNAc", "O-Man", "O-Fuc", or "O-Glc".
+#'   Must be one of the valid `glycan_type` values accepted by [experiment()].
 #'   If not supplied, will try to extract from metadata.
 #'   If unavailable there, an error is issued unless `exp_type` is "others",
 #'   where `NULL` is allowed.
@@ -120,7 +120,7 @@ from_se <- function(
   )
   checkmate::assert_choice(
     glycan_type,
-    c("N", "O-GalNAc", "O-GlcNAc", "O-Man", "O-Fuc", "O-Glc"),
+    .valid_glycan_types(),
     null.ok = TRUE
   )
 
@@ -164,7 +164,7 @@ from_se <- function(
   )
   checkmate::assert_choice(
     glycan_type,
-    c("N", "O-GalNAc", "O-GlcNAc", "O-Man", "O-Fuc", "O-Glc"),
+    .valid_glycan_types(),
     null.ok = exp_type == "others"
   )
 

--- a/man/GlycomicSE.Rd
+++ b/man/GlycomicSE.Rd
@@ -20,7 +20,8 @@ as columns.}
 }
 \item \code{colData}: A \code{S4Vectors::DataFrame()}.
 \item \code{metadata}: A list. It must include a \code{glycan_type} field with one of
-\code{"N"}, \code{"O-GalNAc"}, \code{"O-GlcNAc"}, \code{"O-Man"}, \code{"O-Fuc"}, or \code{"O-Glc"}.
+\code{"N"}, \code{"O"}, \code{"O-GalNAc"}, \code{"O-Man"}, \code{"O-Fuc"}, \code{"O-GlcNAc"},
+\code{"O-Glc"}, \code{"HMO"}, \code{"GSL"}, \code{"GAG"}, or \code{"GPI"}.
 }}
 }
 \value{

--- a/man/GlycoproteomicSE.Rd
+++ b/man/GlycoproteomicSE.Rd
@@ -22,7 +22,8 @@ as rows and samples as columns.}
 }
 \item \code{colData}: A \code{S4Vectors::DataFrame()}.
 \item \code{metadata}: A list. It must include a \code{glycan_type} field with one of
-\code{"N"}, \code{"O-GalNAc"}, \code{"O-GlcNAc"}, \code{"O-Man"}, \code{"O-Fuc"}, or \code{"O-Glc"}.
+\code{"N"}, \code{"O"}, \code{"O-GalNAc"}, \code{"O-Man"}, \code{"O-Fuc"}, \code{"O-GlcNAc"},
+\code{"O-Glc"}, \code{"HMO"}, \code{"GSL"}, \code{"GAG"}, or \code{"GPI"}.
 }}
 }
 \value{

--- a/man/experiment.Rd
+++ b/man/experiment.Rd
@@ -137,7 +137,8 @@ Other meta data can be added to the \code{meta_data} attribute.
 Two meta data fields are required:
 \itemize{
 \item \code{exp_type}: "glycomics", "glycoproteomics", "traitomics", "traitproteomics", or "others"
-\item \code{glycan_type}: "N", "O-GalNAc", "O-GlcNAc", "O-Man", "O-Fuc", "O-Glc", or NULL
+\item \code{glycan_type}: "N", "O", "O-GalNAc", "O-Man", "O-Fuc",
+"O-GlcNAc", "O-Glc", "HMO", "GSL", "GAG", "GPI", or NULL
 }
 
 Other meta data will be added by other \code{glycoverse} packages for their own purposes.

--- a/man/experiment.Rd
+++ b/man/experiment.Rd
@@ -39,7 +39,7 @@ Must be provided if \code{exp_type} is not "others".}
 Default to "others".}
 
 \item{glycan_type}{The type of glycan.
-One of "N", "O-GalNAc", "O-GlcNAc", "O-Man", "O-Fuc", "O-Glc".
+One of the valid \code{glycan_type} values listed in the metadata details.
 Can also be NULL if \code{exp_type} is "others".}
 
 \item{coerce_col_types}{If common column types are coerced. Default to TRUE.

--- a/man/from_se.Rd
+++ b/man/from_se.Rd
@@ -19,7 +19,7 @@ If not supplied, will try to extract from metadata.
 If unavailable there, an error is issued.}
 
 \item{glycan_type}{Character string specifying glycan type.
-Must be either "N", "O-GalNAc", "O-GlcNAc", "O-Man", "O-Fuc", or "O-Glc".
+Must be one of the valid \code{glycan_type} values accepted by \code{\link[=experiment]{experiment()}}.
 If not supplied, will try to extract from metadata.
 If unavailable there, an error is issued unless \code{exp_type} is "others",
 where \code{NULL} is allowed.}

--- a/man/get_meta_data.Rd
+++ b/man/get_meta_data.Rd
@@ -25,7 +25,8 @@ The value of the meta data field. If the field does not exist,
 \description{
 Meta data is some descriptions about the experiment,
 like the experiment type ("glycomics" or "glycoproteomics"),
-or the glycan type ("N", "O-GalNAc", "O-GlcNAc", "O-Man", "O-Fuc", or "O-Glc").
+or the glycan type ("N", "O", "O-GalNAc", "O-Man", "O-Fuc",
+"O-GlcNAc", "O-Glc", "HMO", "GSL", "GAG", or "GPI").
 }
 \examples{
 get_meta_data(real_experiment)

--- a/man/set_meta_data.Rd
+++ b/man/set_meta_data.Rd
@@ -26,5 +26,6 @@ The modified \code{\link[=experiment]{experiment()}} object.
 \description{
 Set meta data values for the experiment,
 like the experiment type ("glycomics" or "glycoproteomics"),
-or the glycan type ("N", "O-GalNAc", "O-GlcNAc", "O-Man", "O-Fuc", or "O-Glc").
+or the glycan type ("N", "O", "O-GalNAc", "O-Man", "O-Fuc",
+"O-GlcNAc", "O-Glc", "HMO", "GSL", "GAG", or "GPI").
 }

--- a/tests/testthat/_snaps/experiment.md
+++ b/tests/testthat/_snaps/experiment.md
@@ -98,7 +98,7 @@
       experiment(expr_mat, sample_info, var_info, "glycomics", "invalid_type")
     Condition
       Error in `.check_meta_data()`:
-      ! `glycan_type` must be one of "N", "O-GalNAc", "O-GlcNAc", "O-Man", "O-Fuc", or "O-Glc".
+      ! `glycan_type` must be one of "N", "O", "O-GalNAc", "O-Man", "O-Fuc", "O-GlcNAc", "O-Glc", "HMO", "GSL", "GAG", "GPI".
       x Got "invalid_type".
 
 # experiment checks required columns in var_info

--- a/tests/testthat/_snaps/meta-data.md
+++ b/tests/testthat/_snaps/meta-data.md
@@ -13,6 +13,6 @@
       set_meta_data(exp, "glycan_type", "invalid_type")
     Condition
       Error in `.check_meta_data()`:
-      ! `glycan_type` must be one of "N", "O-GalNAc", "O-GlcNAc", "O-Man", "O-Fuc", or "O-Glc".
+      ! `glycan_type` must be one of "N", "O", "O-GalNAc", "O-Man", "O-Fuc", "O-GlcNAc", "O-Glc", "HMO", "GSL", "GAG", "GPI".
       x Got "invalid_type".
 

--- a/tests/testthat/test-experiment.R
+++ b/tests/testthat/test-experiment.R
@@ -219,6 +219,29 @@ test_that("experiment validates glycan_type parameter", {
   sample_info <- create_sample_info(c("S1", "S2", "S3"))
   var_info <- create_valid_glycomics_var_info(c("V1", "V2", "V3"))
 
+  valid_glycan_types <- c(
+    "N",
+    "O",
+    "O-GalNAc",
+    "O-Man",
+    "O-Fuc",
+    "O-GlcNAc",
+    "HMO",
+    "GSL",
+    "GAG",
+    "GPI"
+  )
+  purrr::walk(valid_glycan_types, \(glycan_type) {
+    exp <- experiment(
+      expr_mat,
+      sample_info,
+      var_info,
+      "glycomics",
+      glycan_type
+    )
+    expect_equal(exp$meta_data$glycan_type, glycan_type)
+  })
+
   expect_snapshot(
     experiment(expr_mat, sample_info, var_info, "glycomics", "invalid_type"),
     error = TRUE

--- a/tests/testthat/test-glyco-se.R
+++ b/tests/testthat/test-glyco-se.R
@@ -72,6 +72,27 @@ test_that("GlycomicSE requires exactly one non-negative abundance assay", {
 test_that("GlycomicSE validates glycan_type metadata", {
   abundance <- glycomic_abundance()
   row_data <- glycomic_row_data()
+  valid_glycan_types <- c(
+    "N",
+    "O",
+    "O-GalNAc",
+    "O-Man",
+    "O-Fuc",
+    "O-GlcNAc",
+    "HMO",
+    "GSL",
+    "GAG",
+    "GPI"
+  )
+
+  purrr::walk(valid_glycan_types, \(glycan_type) {
+    se <- GlycomicSE(
+      abundance,
+      rowData = row_data,
+      metadata = list(glycan_type = glycan_type)
+    )
+    expect_equal(S4Vectors::metadata(se)$glycan_type, glycan_type)
+  })
 
   expect_error(
     GlycomicSE(abundance, rowData = row_data),

--- a/tests/testthat/test-meta-data.R
+++ b/tests/testthat/test-meta-data.R
@@ -122,17 +122,26 @@ test_that("set_exp_type validates required columns for traitproteomics", {
 test_that("set_glycan_type works", {
   exp <- toy_experiment
 
-  # Test setting glycan_type
-  result <- set_glycan_type(exp, "O-GalNAc")
-  expect_equal(get_glycan_type(result), "O-GalNAc")
+  valid_glycan_types <- c(
+    "N",
+    "O",
+    "O-GalNAc",
+    "O-Man",
+    "O-Fuc",
+    "O-GlcNAc",
+    "HMO",
+    "GSL",
+    "GAG",
+    "GPI"
+  )
+  purrr::walk(valid_glycan_types, \(glycan_type) {
+    result <- set_glycan_type(exp, glycan_type)
+    expect_equal(get_glycan_type(result), glycan_type)
+  })
 
   # Test setting glycan_type to NULL
   result <- set_glycan_type(exp, NULL)
   expect_null(get_glycan_type(result))
-
-  # Test with different glycan_type values
-  result <- set_glycan_type(exp, "N")
-  expect_equal(get_glycan_type(result), "N")
 
   # Test setting glycan_type to an invalid value
   expect_error(set_glycan_type(exp, "invalid_type"))

--- a/tests/testthat/test-se.R
+++ b/tests/testthat/test-se.R
@@ -92,6 +92,20 @@ test_that("from_se works with metadata defaults", {
   expect_equal(exp_back$meta_data$glycan_type, exp$meta_data$glycan_type)
 })
 
+test_that("from_se accepts all valid glycan types from arguments and metadata", {
+  se <- as_se(toy_experiment)
+  valid_glycan_types <- .valid_glycan_types()
+
+  purrr::walk(valid_glycan_types, \(glycan_type) {
+    exp_back <- from_se(se, glycan_type = glycan_type)
+    expect_equal(exp_back$meta_data$glycan_type, glycan_type)
+
+    S4Vectors::metadata(se)$glycan_type <- glycan_type
+    exp_back <- from_se(se)
+    expect_equal(exp_back$meta_data$glycan_type, glycan_type)
+  })
+})
+
 test_that("from_se preserves all metadata", {
   exp <- toy_experiment
   exp$meta_data$instrument <- "Orbitrap"


### PR DESCRIPTION
## Summary

Expand `glycan_type` validation to accept the additional glycan classes requested for glyexp metadata, SummarizedExperiment subclass metadata, and `from_se()` conversion.

## Details

- Adds a shared internal `glycan_type` allow-list used by `experiment()` metadata validation, GlycoSE metadata validation, and `from_se()` argument/metadata validation.
- Accepts `"O"`, `"HMO"`, `"GSL"`, `"GAG"`, and `"GPI"` while retaining the previously accepted `"O-Glc"` value.
- Updates documentation, invalid-value snapshots, and tests for `experiment()`, `set_glycan_type()`, `GlycomicSE()`, and `from_se()`.

## Verification

- `Rscript -e 'devtools::document()'`
- `Rscript -e 'devtools::test(filter = "experiment")'`
- `Rscript -e 'devtools::test(filter = "meta-data")'`
- `Rscript -e 'devtools::test(filter = "glyco-se")'`
- `Rscript -e 'devtools::test(filter = "se")'` - 222 passed in filtered run
- `Rscript -e 'devtools::test()'` - 611 passed
- `air format R/experiment.R R/meta-data.R R/glyco-se.R tests/testthat/test-experiment.R tests/testthat/test-meta-data.R tests/testthat/test-glyco-se.R`
- `air format R/se.R R/experiment.R tests/testthat/test-se.R`
- `git diff --check`
- `Rscript -e 'devtools::check()'` - 0 errors, 0 warnings, 1 NOTE for remote system-clock verification in the sandboxed environment
