### PR TITLE
Support native glyco SE inputs in standardize_variable()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # glyexp (development version)
 
+* `standardize_variable()` now supports `GlycomicSE` and `GlycoproteomicSE` inputs while preserving their container metadata. (#24)
+
 # glyexp 0.15.0
 
 ## New features

--- a/R/standardize-variable.R
+++ b/R/standardize-variable.R
@@ -84,9 +84,14 @@ standardize_variable <- function(exp, format = NULL, unique_suffix = "-{N}") {
   } else {
     .require_se()
     exp_type <- if (is_glycomic) "glycomics" else "glycoproteomics"
-    var_info <- tibble::as_tibble(
-      SummarizedExperiment::rowData(exp),
-      rownames = "variable"
+    var_info <- tibble::as_tibble(SummarizedExperiment::rowData(exp))
+    if ("variable" %in% colnames(var_info)) {
+      var_info$variable <- NULL
+    }
+    var_info <- tibble::add_column(
+      var_info,
+      variable = rownames(exp),
+      .before = 1
     )
   }
 

--- a/R/standardize-variable.R
+++ b/R/standardize-variable.R
@@ -13,7 +13,7 @@
 #' If duplicate IDs are generated (e.g., same composition with multiple PSMs),
 #' a unique integer suffix is appended using the `unique_suffix` pattern.
 #'
-#' @param exp An [experiment()].
+#' @param exp An [experiment()], [GlycomicSE()], or [GlycoproteomicSE()].
 #' @param format A format string specifying how to construct variable IDs.
 #'   Use `{column_name}` to insert values from `var_info` columns.
 #'   For example, `"{gene}-{glycan_composition}"` would produce "GENE1-Hex(5)".
@@ -22,7 +22,8 @@
 #'   Must contain `{N}` which will be replaced with the numeric suffix (1, 2, 3...).
 #'   Default is `"-{N}"` which produces IDs like "Hex(5)-1", "Hex(5)-2".
 #'
-#' @return The experiment with standardized variable IDs.
+#' @return `exp` with standardized variable IDs. The input container class is
+#'   preserved.
 #'
 #' @examples
 #' # Glycomics example
@@ -60,8 +61,14 @@
 #'
 #' @export
 standardize_variable <- function(exp, format = NULL, unique_suffix = "-{N}") {
-  if (!is_experiment(exp)) {
-    cli::cli_abort("{.arg exp} must be an experiment.")
+  is_legacy_experiment <- is_experiment(exp)
+  is_glycomic <- is_glycomic_se(exp)
+  is_glycoproteomic <- is_glycoproteomic_se(exp)
+
+  if (!is_legacy_experiment && !is_glycomic && !is_glycoproteomic) {
+    cli::cli_abort(
+      "{.arg exp} must be an experiment, GlycomicSE, or GlycoproteomicSE."
+    )
   }
 
   # Validate unique_suffix contains {N}
@@ -71,8 +78,17 @@ standardize_variable <- function(exp, format = NULL, unique_suffix = "-{N}") {
     )
   }
 
-  exp_type <- exp$meta_data$exp_type
-  var_info <- exp$var_info
+  if (is_legacy_experiment) {
+    exp_type <- exp$meta_data$exp_type
+    var_info <- exp$var_info
+  } else {
+    .require_se()
+    exp_type <- if (is_glycomic) "glycomics" else "glycoproteomics"
+    var_info <- tibble::as_tibble(
+      SummarizedExperiment::rowData(exp),
+      rownames = "variable"
+    )
+  }
 
   # Determine format if not provided
   if (is.null(format)) {
@@ -94,9 +110,13 @@ standardize_variable <- function(exp, format = NULL, unique_suffix = "-{N}") {
   # Ensure uniqueness by adding suffix if needed
   new_vars <- .ensure_unique(new_vars, unique_suffix)
 
-  # Update var_info and expr_mat
-  exp$var_info$variable <- new_vars
-  rownames(exp$expr_mat) <- new_vars
+  if (is_legacy_experiment) {
+    # Update var_info and expr_mat
+    exp$var_info$variable <- new_vars
+    rownames(exp$expr_mat) <- new_vars
+  } else {
+    rownames(exp) <- new_vars
+  }
 
   exp
 }

--- a/man/standardize_variable.Rd
+++ b/man/standardize_variable.Rd
@@ -7,7 +7,7 @@
 standardize_variable(exp, format = NULL, unique_suffix = "-{N}")
 }
 \arguments{
-\item{exp}{An \code{\link[=experiment]{experiment()}}.}
+\item{exp}{An \code{\link[=experiment]{experiment()}}, \code{\link[=GlycomicSE]{GlycomicSE()}}, or \code{\link[=GlycoproteomicSE]{GlycoproteomicSE()}}.}
 
 \item{format}{A format string specifying how to construct variable IDs.
 Use \code{{column_name}} to insert values from \code{var_info} columns.
@@ -19,7 +19,8 @@ Must contain \code{{N}} which will be replaced with the numeric suffix (1, 2, 3.
 Default is \code{"-{N}"} which produces IDs like "Hex(5)-1", "Hex(5)-2".}
 }
 \value{
-The experiment with standardized variable IDs.
+\code{exp} with standardized variable IDs. The input container class is
+preserved.
 }
 \description{
 Converts meaningless variable IDs (like "GP1", "V1") into meaningful,

--- a/tests/testthat/test-standardize-variable.R
+++ b/tests/testthat/test-standardize-variable.R
@@ -206,6 +206,105 @@ test_that("standardize_variable works with custom unique_suffix", {
   )
 })
 
+test_that("standardize_variable supports GlycomicSE without exp_type metadata", {
+  abundance <- matrix(
+    1:4,
+    nrow = 2,
+    dimnames = list(c("V1", "V2"), c("S1", "S2"))
+  )
+  row_data <- S4Vectors::DataFrame(
+    glycan_composition = rep(
+      glyrepr::glycan_composition(c(Hex = 5, HexNAc = 2)),
+      2
+    ),
+    annotation = c("first", "second"),
+    row.names = c("V1", "V2")
+  )
+  col_data <- S4Vectors::DataFrame(
+    group = c("control", "case"),
+    row.names = c("S1", "S2")
+  )
+  exp <- GlycomicSE(
+    abundance,
+    rowData = row_data,
+    colData = col_data,
+    metadata = list(glycan_type = "N", source = "native-se")
+  )
+  names(SummarizedExperiment::assays(exp)) <- "intensity"
+
+  result <- standardize_variable(exp)
+
+  expected_variables <- c("Hex(5)HexNAc(2)-1", "Hex(5)HexNAc(2)-2")
+  expected_abundance <- abundance
+  rownames(expected_abundance) <- expected_variables
+  expected_row_data <- row_data
+  rownames(expected_row_data) <- expected_variables
+
+  expect_s4_class(result, "GlycomicSE")
+  expect_equal(rownames(result), expected_variables)
+  expect_equal(names(SummarizedExperiment::assays(result)), "intensity")
+  expect_equal(SummarizedExperiment::assay(result), expected_abundance)
+  expect_equal(SummarizedExperiment::rowData(result), expected_row_data)
+  expect_equal(SummarizedExperiment::colData(result), col_data)
+  expect_equal(S4Vectors::metadata(result), S4Vectors::metadata(exp))
+})
+
+test_that("standardize_variable supports GlycoproteomicSE without exp_type metadata", {
+  abundance <- matrix(
+    1:4,
+    nrow = 2,
+    dimnames = list(c("GP1", "GP2"), c("S1", "S2"))
+  )
+  row_data <- S4Vectors::DataFrame(
+    protein = c("P12345", "P12345"),
+    protein_site = c(32L, NA_integer_),
+    glycan_composition = rep(
+      glyrepr::glycan_composition(c(Hex = 5, HexNAc = 2)),
+      2
+    ),
+    annotation = c("first", "second"),
+    row.names = c("GP1", "GP2")
+  )
+  col_data <- S4Vectors::DataFrame(
+    group = c("control", "case"),
+    row.names = c("S1", "S2")
+  )
+  exp <- GlycoproteomicSE(
+    abundance,
+    rowData = row_data,
+    colData = col_data,
+    metadata = list(glycan_type = "N", source = "native-se")
+  )
+  names(SummarizedExperiment::assays(exp)) <- "intensity"
+
+  result <- standardize_variable(exp)
+
+  expected_variables <- c(
+    "P12345-32-Hex(5)HexNAc(2)",
+    "P12345-X-Hex(5)HexNAc(2)"
+  )
+  expected_abundance <- abundance
+  rownames(expected_abundance) <- expected_variables
+  expected_row_data <- row_data
+  rownames(expected_row_data) <- expected_variables
+
+  expect_s4_class(result, "GlycoproteomicSE")
+  expect_equal(rownames(result), expected_variables)
+  expect_equal(names(SummarizedExperiment::assays(result)), "intensity")
+  expect_equal(SummarizedExperiment::assay(result), expected_abundance)
+  expect_equal(SummarizedExperiment::rowData(result), expected_row_data)
+  expect_equal(SummarizedExperiment::colData(result), col_data)
+  expect_equal(S4Vectors::metadata(result), S4Vectors::metadata(exp))
+})
+
+test_that("standardize_variable rejects arbitrary SummarizedExperiment objects", {
+  se <- SummarizedExperiment::SummarizedExperiment(
+    assays = list(abundance = matrix(1:4, nrow = 2))
+  )
+
+  expect_error(standardize_variable(se), "GlycomicSE")
+})
+
 # Tests for .get_default_format
 test_that(".get_default_format returns correct format for glycomics", {
   var_info <- tibble::tibble(

--- a/tests/testthat/test-standardize-variable.R
+++ b/tests/testthat/test-standardize-variable.R
@@ -297,6 +297,39 @@ test_that("standardize_variable supports GlycoproteomicSE without exp_type metad
   expect_equal(S4Vectors::metadata(result), S4Vectors::metadata(exp))
 })
 
+test_that("standardize_variable uses SE row names over rowData variable columns", {
+  abundance <- matrix(
+    1:4,
+    nrow = 2,
+    dimnames = list(c("V1", "V2"), c("S1", "S2"))
+  )
+  row_data <- S4Vectors::DataFrame(
+    variable = c("stale-1", "stale-2"),
+    glycan_composition = rep(
+      glyrepr::glycan_composition(c(Hex = 5, HexNAc = 2)),
+      2
+    ),
+    row.names = c("V1", "V2")
+  )
+  exp <- GlycomicSE(
+    abundance,
+    rowData = row_data,
+    metadata = list(glycan_type = "N")
+  )
+
+  result <- standardize_variable(exp, "{variable}-{glycan_composition}")
+
+  expected_variables <- c(
+    "V1-Hex(5)HexNAc(2)",
+    "V2-Hex(5)HexNAc(2)"
+  )
+  expected_row_data <- row_data
+  rownames(expected_row_data) <- expected_variables
+
+  expect_equal(rownames(result), expected_variables)
+  expect_equal(SummarizedExperiment::rowData(result), expected_row_data)
+})
+
 test_that("standardize_variable rejects arbitrary SummarizedExperiment objects", {
   se <- SummarizedExperiment::SummarizedExperiment(
     assays = list(abundance = matrix(1:4, nrow = 2))


### PR DESCRIPTION
## Summary

- Add native `GlycomicSE` and `GlycoproteomicSE` support to `standardize_variable()`.

## Background

`glyclean` currently round-trips glyco SE subclasses through the legacy `experiment()` container to standardize IDs.

## Details

- Infer glycomics or glycoproteomics defaults from the SE subclass without requiring `metadata(exp_type)`.
- Preserve the input subclass, assay name, `rowData`, `colData`, and metadata while updating variable IDs.
- Reject arbitrary `SummarizedExperiment` inputs and retain legacy traitomics and traitproteomics behavior.
- Add regression coverage for both native subclasses and the unsupported generic SE case.

## Verification

- `Rscript -e 'devtools::document()'`
- `Rscript -e 'devtools::test(filter = "standardize-variable")'` (29 passed)
- `Rscript -e 'devtools::test()'` (628 passed)
- `Rscript -e 'devtools::check(document = FALSE, manual = FALSE, cran = FALSE)'` (0 errors, 0 warnings, 0 notes)
- `air format R/standardize-variable.R tests/testthat/test-standardize-variable.R`
- `git diff --check`

Closes #23