### PR TITLE
feat: support SummarizedExperiment in tidy verbs

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # glyexp (development version)
 
-* All tidy manipulation verbs (`filter_*()`, `mutate_*()`, `select_*()`, `arrange_*()`, `rename_*()`, `slice_*()`, and `*_join_*()`) now accept `SummarizedExperiment` objects while retaining existing `experiment()` behavior.
+* All tidy manipulation verbs (`filter_*()`, `mutate_*()`, `select_*()`, `arrange_*()`, `rename_*()`, `slice_*()`, and `*_join_*()`) now accept `SummarizedExperiment` objects, exposing dimension identifiers as virtual `.sample` and `.variable` columns while retaining existing `experiment()` behavior.
 * `standardize_variable()` now supports `GlycomicSE` and `GlycoproteomicSE` inputs while preserving their container metadata. (#24)
 
 # glyexp 0.15.0

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # glyexp (development version)
 
-* All tidy manipulation verbs (`filter_*()`, `mutate_*()`, `select_*()`, `arrange_*()`, `rename_*()`, `slice_*()`, and `*_join_*()`) now accept `SummarizedExperiment` objects, exposing dimension identifiers as virtual `.sample` and `.variable` columns while retaining existing `experiment()` behavior.
+* All tidy manipulation verbs (`filter_*()`, `mutate_*()`, `select_*()`, `arrange_*()`, `rename_*()`, `slice_*()`, and `*_join_*()`) now accept `SummarizedExperiment` objects, exposing dimension identifiers as virtual `.sample` and `.variable` columns while retaining existing `experiment()` behavior. (#25)
 * `standardize_variable()` now supports `GlycomicSE` and `GlycoproteomicSE` inputs while preserving their container metadata. (#24)
 
 # glyexp 0.15.0

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # glyexp (development version)
 
+* All tidy manipulation verbs (`filter_*()`, `mutate_*()`, `select_*()`, `arrange_*()`, `rename_*()`, `slice_*()`, and `*_join_*()`) now accept `SummarizedExperiment` objects while retaining existing `experiment()` behavior.
 * `standardize_variable()` now supports `GlycomicSE` and `GlycoproteomicSE` inputs while preserving their container metadata. (#24)
 
 # glyexp 0.15.0

--- a/R/dplyr-arrange.R
+++ b/R/dplyr-arrange.R
@@ -64,6 +64,7 @@ arrange_var <- function(exp, ...) {
 # Internal function that handles the common logic for both arrange_obs and arrange_var
 arrange_info_data <- function(exp, info_field, id_column, matrix_updater, ...) {
   stopifnot(is_tidy_container(exp))
+  id_column <- tidy_id_column(exp, id_column)
 
   # Get original data and arrange it
   original_data <- tidy_info_data(exp, info_field, id_column)

--- a/R/dplyr-arrange.R
+++ b/R/dplyr-arrange.R
@@ -17,6 +17,7 @@
 #'
 #' @return An object of the same class as `exp`.
 #'
+#' @inheritSection mutate_obs Identifier columns
 #' @examples
 #' # Create a toy experiment for demonstration
 #' exp <- toy_experiment |>

--- a/R/dplyr-arrange.R
+++ b/R/dplyr-arrange.R
@@ -1,7 +1,8 @@
 #' Arrange sample or variable information
 #'
 #' @description
-#' Arrange the sample or variable information tibble of an [experiment()].
+#' Arrange the sample or variable information of an [experiment()] or
+#' `SummarizedExperiment`.
 #'
 #' The same syntax as `dplyr::arrange()` is used.
 #' For example, to arrange samples by the "group" column,
@@ -10,11 +11,11 @@
 #' with the `group` column,
 #' and then updates the expression matrix accordingly to match the new order.
 #'
-#' @param exp An [experiment()].
+#' @param exp An [experiment()] or `SummarizedExperiment` object.
 #' @param ... <[`data-masking`][rlang::args_data_masking]> Variables to arrange by,
 #'   passed to `dplyr::arrange()` internally.
 #'
-#' @return An new [experiment()] object.
+#' @return An object of the same class as `exp`.
 #'
 #' @examples
 #' # Create a toy experiment for demonstration
@@ -61,11 +62,15 @@ arrange_var <- function(exp, ...) {
 
 # Internal function that handles the common logic for both arrange_obs and arrange_var
 arrange_info_data <- function(exp, info_field, id_column, matrix_updater, ...) {
-  stopifnot(is_experiment(exp))
+  stopifnot(is_tidy_container(exp))
 
   # Get original data and arrange it
-  original_data <- exp[[info_field]]
+  original_data <- tidy_info_data(exp, info_field, id_column)
   new_data <- try_arrange(original_data, info_field, ...)
+
+  if (methods::is(exp, "SummarizedExperiment")) {
+    return(update_se_info(exp, new_data, info_field, id_column, subset = TRUE))
+  }
 
   # Update the expression matrix using the new order
   new_ids <- new_data[[id_column]]

--- a/R/dplyr-filter.R
+++ b/R/dplyr-filter.R
@@ -24,6 +24,7 @@
 #'
 #' @return An object of the same class as `exp`.
 #'
+#' @inheritSection mutate_obs Identifier columns
 #' @examples
 #' # Create a toy experiment for demonstration
 #' exp <- toy_experiment |>

--- a/R/dplyr-filter.R
+++ b/R/dplyr-filter.R
@@ -86,6 +86,7 @@ filter_info_data <- function(
   .drop_levels
 ) {
   stopifnot(is_tidy_container(exp))
+  id_column <- tidy_id_column(exp, id_column)
 
   # Get original data and filter it
   original_data <- tidy_info_data(exp, info_field, id_column)

--- a/R/dplyr-filter.R
+++ b/R/dplyr-filter.R
@@ -1,7 +1,8 @@
 #' Filter samples or variables of an experiment
 #'
 #' @description
-#' Getting a subset of an [experiment()] by filtering samples or variables.
+#' Getting a subset of an [experiment()] or `SummarizedExperiment` by filtering
+#' samples or variables.
 #'
 #' The same syntax as [dplyr::filter()] is used.
 #' For example, to get a subset of an experiment keeping only "HC" samples,
@@ -15,13 +16,13 @@
 #' when filtering on factor columns, the unused levels are automatically dropped by default.
 #' This behavior can be turnt off by setting `.drop_levels` to FALSE.
 #'
-#' @param exp An [experiment()].
+#' @param exp An [experiment()] or `SummarizedExperiment` object.
 #' @param ... <[`data-masking`][rlang::args_data_masking]> Expression to filter samples or variables.
 #'   passed to [dplyr::filter()] internally.
 #' @param .drop_levels Logical. If `TRUE`, drop unused factor levels for columns
 #'   referenced in the filtering expressions.
 #'
-#' @return An new [experiment()] object.
+#' @return An object of the same class as `exp`.
 #'
 #' @examples
 #' # Create a toy experiment for demonstration
@@ -83,14 +84,18 @@ filter_info_data <- function(
   ...,
   .drop_levels
 ) {
-  stopifnot(is_experiment(exp))
+  stopifnot(is_tidy_container(exp))
 
   # Get original data and filter it
-  original_data <- exp[[info_field]]
+  original_data <- tidy_info_data(exp, info_field, id_column)
   quos <- rlang::enquos(...)
   new_data <- try_filter(original_data, info_field, dim_name, quos)
   if (isTRUE(.drop_levels)) {
     new_data <- drop_filter_levels(new_data, original_data, quos)
+  }
+
+  if (methods::is(exp, "SummarizedExperiment")) {
+    return(update_se_info(exp, new_data, info_field, id_column, subset = TRUE))
   }
 
   # Update the expression matrix using the provided updater function

--- a/R/dplyr-join.R
+++ b/R/dplyr-join.R
@@ -2,11 +2,13 @@
 #'
 #' @description
 #' These functions allow you to join additional data to the sample information
-#' or variable information of an [experiment()]. They work similarly to
+#' or variable information of an [experiment()] or `SummarizedExperiment`.
+#' They work similarly to
 #' [dplyr::left_join()], [dplyr::inner_join()], [dplyr::semi_join()], and
-#' [dplyr::anti_join()], but are designed to work with experiment objects.
+#' [dplyr::anti_join()], while keeping assay dimensions synchronized with the
+#' joined metadata.
 #'
-#' After joining, the `expr_mat` is automatically updated to reflect any
+#' After joining, the assay dimensions are automatically updated to reflect any
 #' changes in the number of samples or variables.
 #'
 #' **Important Notes:**
@@ -16,14 +18,15 @@
 #' - `right_join()` and `full_join()` are not supported as they could add
 #'   new observations to the experiment.
 #'
-#' @param exp An [experiment()].
+#' @param exp An [experiment()] or `SummarizedExperiment` object.
 #' @param y A data frame to join to `sample_info` or `var_info`.
 #' @param by A join specification created with [dplyr::join_by()], or a
 #'   character vector of variables to join by. See [dplyr::left_join()] for details.
 #' @param ... Other arguments passed to the underlying dplyr join function,
 #'   except `relationship` which is locked to "many-to-one".
 #'
-#' @return A new [experiment()] object with updated sample or variable information.
+#' @return An object of the same class as `exp`, with updated sample or variable
+#'   information.
 #'
 #' @examples
 #' library(dplyr)
@@ -199,7 +202,7 @@ join_info_data <- function(
   ...
 ) {
   # Input validation
-  stopifnot(is_experiment(exp))
+  stopifnot(is_tidy_container(exp))
 
   # Check if user tries to specify relationship parameter
   dots <- list(...)
@@ -214,7 +217,7 @@ join_info_data <- function(
   }
 
   # Get original data
-  original_data <- exp[[info_field]]
+  original_data <- tidy_info_data(exp, info_field, id_column)
 
   # Perform the join
   # Only apply relationship constraint for joins that can increase row count
@@ -240,6 +243,10 @@ join_info_data <- function(
       dim_name = dim_name,
       ...
     )
+  }
+
+  if (methods::is(exp, "SummarizedExperiment")) {
+    return(update_se_info(exp, new_data, info_field, id_column, subset = TRUE))
   }
 
   # Update the expression matrix using the provided updater function

--- a/R/dplyr-join.R
+++ b/R/dplyr-join.R
@@ -204,6 +204,7 @@ join_info_data <- function(
 ) {
   # Input validation
   stopifnot(is_tidy_container(exp))
+  id_column <- tidy_id_column(exp, id_column)
 
   # Check if user tries to specify relationship parameter
   dots <- list(...)

--- a/R/dplyr-join.R
+++ b/R/dplyr-join.R
@@ -28,6 +28,7 @@
 #' @return An object of the same class as `exp`, with updated sample or variable
 #'   information.
 #'
+#' @inheritSection mutate_obs Identifier columns
 #' @examples
 #' library(dplyr)
 #' library(tibble)

--- a/R/dplyr-mutate.R
+++ b/R/dplyr-mutate.R
@@ -21,6 +21,25 @@
 #'
 #' @return An object of the same class as `exp`.
 #'
+#' @section Identifier columns:
+#' For an [experiment()] object, `sample` is a physical column in
+#' `sample_info`, and `variable` is a physical column in `var_info`.
+#'
+#' For a `SummarizedExperiment`, sample and variable identifiers normally live
+#' in `colnames(exp)` and `rownames(exp)`, rather than in
+#' [SummarizedExperiment::colData()] or [SummarizedExperiment::rowData()].
+#' During tidy evaluation, these names are exposed as virtual `sample` and
+#' `variable` columns, so they can be referenced in the same way as the
+#' physical columns of an [experiment()] object. After the operation, virtual
+#' columns are removed from the metadata and their values are written back to
+#' the corresponding dimension names. They receive the same protection as the
+#' physical index columns.
+#'
+#' If `colData(exp)` already contains a `sample` column or `rowData(exp)`
+#' already contains a `variable` column, that stored column is used as the
+#' identifier, preserved in the metadata, and kept synchronized with the
+#' corresponding dimension names.
+#'
 #' @examples
 #' # Create a toy experiment for demonstration
 #' exp <- toy_experiment |>

--- a/R/dplyr-mutate.R
+++ b/R/dplyr-mutate.R
@@ -1,7 +1,8 @@
 #' Mutate sample or variable information
 #'
 #' @description
-#' Mutate the sample or variable information tibble of an [experiment()].
+#' Mutate the sample or variable information of an [experiment()] or
+#' `SummarizedExperiment`.
 #'
 #' The same syntax as `dplyr::mutate()` is used.
 #' For example, to add a new column to the sample information tibble,
@@ -12,13 +13,13 @@
 #' If the `sample` column in `sample_info` or the `variable` column in `var_info`
 #' is to be modified, the new column must be unique,
 #' otherwise an error is thrown.
-#' The column names or row names of `expr_mat` will be updated accordingly.
+#' The assay column names or row names will be updated accordingly.
 #'
-#' @param exp An [experiment()].
+#' @param exp An [experiment()] or `SummarizedExperiment` object.
 #' @param ... <[`data-masking`][rlang::args_data_masking]> Name-value pairs,
 #'   passed to `dplyr::mutate()` internally.
 #'
-#' @return An new [experiment()] object.
+#' @return An object of the same class as `exp`.
 #'
 #' @examples
 #' # Create a toy experiment for demonstration
@@ -95,10 +96,10 @@ mutate_info_data <- function(
   matrix_dimnames_setter,
   ...
 ) {
-  stopifnot(is_experiment(exp))
+  stopifnot(is_tidy_container(exp))
 
   # Get original data and mutate it
-  original_data <- exp[[info_field]]
+  original_data <- tidy_info_data(exp, info_field, id_column)
   new_data <- try_mutate(original_data, info_field, ...)
 
   # Check if the ID column was modified
@@ -114,9 +115,17 @@ mutate_info_data <- function(
       )
     }
     # Update matrix dimnames
-    new_expr_mat <- matrix_dimnames_setter(exp$expr_mat, new_ids)
+    if (is_experiment(exp)) {
+      new_expr_mat <- matrix_dimnames_setter(exp$expr_mat, new_ids)
+    }
   } else {
-    new_expr_mat <- exp$expr_mat
+    if (is_experiment(exp)) {
+      new_expr_mat <- exp$expr_mat
+    }
+  }
+
+  if (methods::is(exp, "SummarizedExperiment")) {
+    return(update_se_info(exp, new_data, info_field, id_column))
   }
 
   # Create new experiment object

--- a/R/dplyr-mutate.R
+++ b/R/dplyr-mutate.R
@@ -10,9 +10,8 @@
 #' This actually calls `dplyr::mutate()` on the sample information tibble
 #' with `new_column = value`.
 #'
-#' If the `sample` column in `sample_info` or the `variable` column in `var_info`
-#' is to be modified, the new column must be unique,
-#' otherwise an error is thrown.
+#' If an identifier column is modified, its new values must be unique;
+#' otherwise, an error is thrown.
 #' The assay column names or row names will be updated accordingly.
 #'
 #' @param exp An [experiment()] or `SummarizedExperiment` object.
@@ -25,20 +24,19 @@
 #' For an [experiment()] object, `sample` is a physical column in
 #' `sample_info`, and `variable` is a physical column in `var_info`.
 #'
-#' For a `SummarizedExperiment`, sample and variable identifiers normally live
-#' in `colnames(exp)` and `rownames(exp)`, rather than in
+#' For a `SummarizedExperiment`, sample and variable identifiers live in
+#' `colnames(exp)` and `rownames(exp)`, rather than in
 #' [SummarizedExperiment::colData()] or [SummarizedExperiment::rowData()].
-#' During tidy evaluation, these names are exposed as virtual `sample` and
-#' `variable` columns, so they can be referenced in the same way as the
-#' physical columns of an [experiment()] object. After the operation, virtual
-#' columns are removed from the metadata and their values are written back to
-#' the corresponding dimension names. They receive the same protection as the
-#' physical index columns.
+#' Observation verbs expose `colnames(exp)` as a virtual `.sample` column, and
+#' variable verbs expose `rownames(exp)` as a virtual `.variable` column. These
+#' dot-prefixed names distinguish dimension identifiers from regular metadata
+#' columns. After the operation, the virtual column is removed and its values
+#' are written back to the corresponding dimension names.
 #'
-#' If `colData(exp)` already contains a `sample` column or `rowData(exp)`
-#' already contains a `variable` column, that stored column is used as the
-#' identifier, preserved in the metadata, and kept synchronized with the
-#' corresponding dimension names.
+#' Consequently, `sample` in `colData(exp)` and `variable` in `rowData(exp)`
+#' remain ordinary metadata columns. The names `.sample` and `.variable` are
+#' reserved; an input containing either name in the corresponding metadata
+#' raises an error rather than overwriting that column.
 #'
 #' @examples
 #' # Create a toy experiment for demonstration
@@ -72,6 +70,11 @@
 #' new_exp <- mutate_var(exp, variable = c("VI", "VII", "VIII", "VIV"))
 #' get_var_info(new_exp)
 #' get_expr_mat(new_exp)
+#'
+#' # SummarizedExperiment identifiers use virtual dot-prefixed columns
+#' se <- as_se(toy_experiment)
+#' mutate_obs(se, .sample = paste0("new_", .sample))
+#' mutate_var(se, .variable = paste0("new_", .variable))
 #'
 #' @export
 mutate_obs <- function(exp, ...) {
@@ -116,6 +119,7 @@ mutate_info_data <- function(
   ...
 ) {
   stopifnot(is_tidy_container(exp))
+  id_column <- tidy_id_column(exp, id_column)
 
   # Get original data and mutate it
   original_data <- tidy_info_data(exp, info_field, id_column)

--- a/R/dplyr-rename.R
+++ b/R/dplyr-rename.R
@@ -53,6 +53,7 @@ rename_var <- function(exp, ...) {
 # Internal function that handles the common logic for both rename_obs and rename_var
 rename_info_data <- function(exp, info_field, id_column, ...) {
   stopifnot(is_tidy_container(exp))
+  id_column <- tidy_id_column(exp, id_column)
 
   # Get original data and rename it
   original_data <- tidy_info_data(exp, info_field, id_column)

--- a/R/dplyr-rename.R
+++ b/R/dplyr-rename.R
@@ -18,6 +18,7 @@
 #'
 #' @returns An object of the same class as `exp`.
 #'
+#' @inheritSection mutate_obs Identifier columns
 #' @examples
 #' toy_exp <- toy_experiment
 #' toy_exp

--- a/R/dplyr-rename.R
+++ b/R/dplyr-rename.R
@@ -71,20 +71,29 @@ rename_info_data <- function(exp, info_field, id_column, ...) {
 }
 
 rename_data <- function(data, data_name, info_type, ...) {
+  protected_columns <- intersect(
+    c(info_type, tidy_position_column()),
+    colnames(data)
+  )
+
   # Create a prototype (empty data frame with same structure) for validation
   prototype <- data[0, ]
 
-  # Remove the ID column from prototype for validation
-  prototype_without_id <- dplyr::select(prototype, -dplyr::all_of(info_type))
+  # Remove protected columns from prototype for validation
+  prototype_without_id <- dplyr::select(
+    prototype,
+    -dplyr::all_of(protected_columns)
+  )
 
   # Try renaming on the prototype first to validate
   validate_rename(prototype_without_id, data_name, info_type, ...)
 
   # If validation passes, perform the actual renaming
-  index_col <- data[[info_type]]
-  new_data <- dplyr::select(data, -dplyr::all_of(info_type))
+  protected_data <- dplyr::select(data, dplyr::all_of(protected_columns))
+  new_data <- dplyr::select(data, -dplyr::all_of(protected_columns))
   new_data <- dplyr::rename(new_data, ...)
-  new_data <- dplyr::mutate(new_data, "{info_type}" := index_col, .before = 1)
+  check_reserved_tidy_columns(new_data, protected_columns, data_name)
+  new_data <- dplyr::bind_cols(protected_data, new_data)
 
   new_data
 }

--- a/R/dplyr-rename.R
+++ b/R/dplyr-rename.R
@@ -2,7 +2,7 @@
 #'
 #' @description
 #' These two functions provide a way to rename columns in the sample or variable
-#' information tibble of an [experiment()].
+#' information of an [experiment()] or `SummarizedExperiment`.
 #'
 #' The same syntax as `dplyr::rename()` is used.
 #' For example, to rename the "group" column in the sample information tibble to "condition",
@@ -12,11 +12,11 @@
 #' These two columns are used to link the sample or variable information tibble
 #' to the expression matrix.
 #'
-#' @param exp An [experiment()].
+#' @param exp An [experiment()] or `SummarizedExperiment` object.
 #' @param ... <[`data-masking`][rlang::args_data_masking]> Name pairs to rename.
 #'   Use `new_name = old_name` to rename columns.
 #'
-#' @returns An new [experiment()] object.
+#' @returns An object of the same class as `exp`.
 #'
 #' @examples
 #' toy_exp <- toy_experiment
@@ -51,11 +51,15 @@ rename_var <- function(exp, ...) {
 
 # Internal function that handles the common logic for both rename_obs and rename_var
 rename_info_data <- function(exp, info_field, id_column, ...) {
-  stopifnot(is_experiment(exp))
+  stopifnot(is_tidy_container(exp))
 
   # Get original data and rename it
-  original_data <- exp[[info_field]]
+  original_data <- tidy_info_data(exp, info_field, id_column)
   new_data <- rename_data(original_data, info_field, id_column, ...)
+
+  if (methods::is(exp, "SummarizedExperiment")) {
+    return(update_se_info(exp, new_data, info_field, id_column))
+  }
 
   # Create new experiment object
   new_exp <- exp

--- a/R/dplyr-select.R
+++ b/R/dplyr-select.R
@@ -29,6 +29,7 @@
 #'
 #' @return An object of the same class as `exp`.
 #'
+#' @inheritSection mutate_obs Identifier columns
 #' @examples
 #' toy_exp <- toy_experiment
 #'

--- a/R/dplyr-select.R
+++ b/R/dplyr-select.R
@@ -84,20 +84,29 @@ select_info_data <- function(exp, info_field, id_column, ...) {
 }
 
 select_data <- function(data, data_name, info_type, ...) {
+  protected_columns <- intersect(
+    c(info_type, tidy_position_column()),
+    colnames(data)
+  )
+
   # Create a prototype (empty data frame with same structure) for validation
   prototype <- data[0, ]
 
-  # Remove the ID column from prototype for validation
-  prototype_without_id <- dplyr::select(prototype, -dplyr::all_of(info_type))
+  # Remove protected columns from prototype for validation
+  prototype_without_id <- dplyr::select(
+    prototype,
+    -dplyr::all_of(protected_columns)
+  )
 
   # Try selection on the prototype first to validate
   validate_selection(prototype_without_id, data_name, info_type, ...)
 
   # If validation passes, perform the actual selection
-  index_col <- data[[info_type]]
-  new_data <- dplyr::select(data, -dplyr::all_of(info_type))
+  protected_data <- dplyr::select(data, dplyr::all_of(protected_columns))
+  new_data <- dplyr::select(data, -dplyr::all_of(protected_columns))
   new_data <- dplyr::select(new_data, ...)
-  new_data <- dplyr::mutate(new_data, "{info_type}" := index_col, .before = 1)
+  check_reserved_tidy_columns(new_data, protected_columns, data_name)
+  new_data <- dplyr::bind_cols(protected_data, new_data)
 
   new_data
 }

--- a/R/dplyr-select.R
+++ b/R/dplyr-select.R
@@ -66,6 +66,7 @@ select_var <- function(exp, ...) {
 # Internal function that handles the common logic for both select_obs and select_var
 select_info_data <- function(exp, info_field, id_column, ...) {
   stopifnot(is_tidy_container(exp))
+  id_column <- tidy_id_column(exp, id_column)
 
   # Get original data and select it
   original_data <- tidy_info_data(exp, info_field, id_column)

--- a/R/dplyr-select.R
+++ b/R/dplyr-select.R
@@ -2,7 +2,8 @@
 #'
 #' @description
 #' These two functions provide a way to trimming down the sample or variable information tibble
-#' of an [experiment()] to only the columns of interest.
+#' of an [experiment()] or `SummarizedExperiment` to only the columns of
+#' interest.
 #'
 #' The same syntax as `dplyr::select()` is used.
 #' For example, to get a new [experiment()] with only the "sample" and "group"
@@ -22,11 +23,11 @@
 #' conflicted::conflicts_prefer(glyexp::select_var)
 #' ```
 #'
-#' @param exp An [experiment()].
+#' @param exp An [experiment()] or `SummarizedExperiment` object.
 #' @param ... <[`data-masking`][rlang::args_data_masking]> Column names to select.
 #'   If empty, all columns except the `sample` or `variable` column will be discarded.
 #'
-#' @return An new [experiment()] object.
+#' @return An object of the same class as `exp`.
 #'
 #' @examples
 #' toy_exp <- toy_experiment
@@ -63,11 +64,15 @@ select_var <- function(exp, ...) {
 
 # Internal function that handles the common logic for both select_obs and select_var
 select_info_data <- function(exp, info_field, id_column, ...) {
-  checkmate::assert_class(exp, "glyexp_experiment")
+  stopifnot(is_tidy_container(exp))
 
   # Get original data and select it
-  original_data <- exp[[info_field]]
+  original_data <- tidy_info_data(exp, info_field, id_column)
   new_data <- select_data(original_data, info_field, id_column, ...)
+
+  if (methods::is(exp, "SummarizedExperiment")) {
+    return(update_se_info(exp, new_data, info_field, id_column))
+  }
 
   # Create new experiment object
   new_exp <- exp

--- a/R/dplyr-slice.R
+++ b/R/dplyr-slice.R
@@ -413,6 +413,7 @@ slice_info_data <- function(
   ...
 ) {
   stopifnot(is_tidy_container(exp))
+  id_column <- tidy_id_column(exp, id_column)
 
   # Get original data and slice it
   original_data <- tidy_info_data(exp, info_field, id_column)

--- a/R/dplyr-slice.R
+++ b/R/dplyr-slice.R
@@ -1,7 +1,8 @@
 #' Slice sample or variable information
 #'
 #' @description
-#' Slice the sample or variable information tibble of an [experiment()].
+#' Slice the sample or variable information of an [experiment()] or
+#' `SummarizedExperiment`.
 #'
 #' These functions provide row-wise slicing operations similar to dplyr's slice functions.
 #' They select rows by position or based on values in specified columns,
@@ -14,7 +15,7 @@
 #' - `slice_max_obs()` and `slice_max_var()`: Select rows with highest values
 #' - `slice_min_obs()` and `slice_min_var()`: Select rows with lowest values
 #'
-#' @param exp An [experiment()].
+#' @param exp An [experiment()] or `SummarizedExperiment` object.
 #' @param ... <[`data-masking`][rlang::args_data_masking]> For `slice_*()`,
 #'   integer row positions. For `slice_max()` and `slice_min()`, variables to
 #'   order by. Other arguments passed to the corresponding dplyr function.
@@ -28,7 +29,7 @@
 #' @param weight_by For `slice_sample()`, sampling weights.
 #' @param replace For `slice_sample()`, should sampling be with replacement?
 #'
-#' @return A new [experiment()] object.
+#' @return An object of the same class as `exp`.
 #'
 #' @examples
 #' # Create a toy experiment for demonstration
@@ -410,11 +411,15 @@ slice_info_data <- function(
   slice_fun,
   ...
 ) {
-  stopifnot(is_experiment(exp))
+  stopifnot(is_tidy_container(exp))
 
   # Get original data and slice it
-  original_data <- exp[[info_field]]
+  original_data <- tidy_info_data(exp, info_field, id_column)
   new_data <- try_slice(original_data, info_field, slice_fun, ...)
+
+  if (methods::is(exp, "SummarizedExperiment")) {
+    return(update_se_info(exp, new_data, info_field, id_column, subset = TRUE))
+  }
 
   # Update the expression matrix using the new order
   new_ids <- new_data[[id_column]]

--- a/R/dplyr-slice.R
+++ b/R/dplyr-slice.R
@@ -31,6 +31,7 @@
 #'
 #' @return An object of the same class as `exp`.
 #'
+#' @inheritSection mutate_obs Identifier columns
 #' @examples
 #' # Create a toy experiment for demonstration
 #' exp <- toy_experiment |>

--- a/R/dplyr-utils.R
+++ b/R/dplyr-utils.R
@@ -23,3 +23,100 @@ abort_missing_column <- function(missing_col, data_name, available_cols) {
     call = NULL
   )
 }
+
+#' Check whether an object is supported by the tidy manipulation verbs
+#'
+#' @param exp An object to check.
+#'
+#' @return A logical scalar.
+#' @noRd
+is_tidy_container <- function(exp) {
+  is_experiment(exp) || methods::is(exp, "SummarizedExperiment")
+}
+
+#' Extract metadata for a tidy manipulation verb
+#'
+#' For `SummarizedExperiment` objects, row or column names are exposed as a
+#' transient `variable` or `sample` column when that column is not already
+#' stored in `rowData` or `colData`.
+#'
+#' @param exp An [experiment()] or `SummarizedExperiment` object.
+#' @param info_field Either `"sample_info"` or `"var_info"`.
+#' @param id_column Either `"sample"` or `"variable"`.
+#'
+#' @return A tibble containing the requested metadata and identifier column.
+#' @noRd
+tidy_info_data <- function(exp, info_field, id_column) {
+  if (is_experiment(exp)) {
+    return(exp[[info_field]])
+  }
+
+  data <- if (info_field == "sample_info") {
+    SummarizedExperiment::colData(exp)
+  } else {
+    SummarizedExperiment::rowData(exp)
+  }
+  data <- tibble::as_tibble(data)
+
+  if (!id_column %in% colnames(data)) {
+    ids <- if (info_field == "sample_info") colnames(exp) else rownames(exp)
+    if (is.null(ids)) {
+      ids <- as.character(seq_len(nrow(data)))
+    }
+    data <- dplyr::mutate(data, "{id_column}" := ids, .before = 1)
+  }
+
+  data
+}
+
+#' Update metadata and dimensions of a SummarizedExperiment
+#'
+#' @param exp A `SummarizedExperiment` object.
+#' @param new_data A data frame containing updated metadata.
+#' @param info_field Either `"sample_info"` or `"var_info"`.
+#' @param id_column Either `"sample"` or `"variable"`.
+#' @param subset Whether to subset and reorder the corresponding dimension.
+#'
+#' @return An updated object of the same class as `exp`.
+#' @noRd
+update_se_info <- function(
+  exp,
+  new_data,
+  info_field,
+  id_column,
+  subset = FALSE
+) {
+  original_data <- if (info_field == "sample_info") {
+    SummarizedExperiment::colData(exp)
+  } else {
+    SummarizedExperiment::rowData(exp)
+  }
+  id_is_stored <- id_column %in% colnames(original_data)
+  new_ids <- new_data[[id_column]]
+
+  if (isTRUE(subset)) {
+    original_ids <- tidy_info_data(exp, info_field, id_column)[[id_column]]
+    indices <- match(new_ids, original_ids)
+    exp <- if (info_field == "sample_info") {
+      exp[, indices, drop = FALSE]
+    } else {
+      exp[indices, , drop = FALSE]
+    }
+  }
+
+  stored_data <- new_data
+  if (!id_is_stored) {
+    stored_data <- dplyr::select(stored_data, -dplyr::all_of(id_column))
+  }
+  stored_data <- S4Vectors::DataFrame(stored_data, row.names = new_ids)
+
+  if (info_field == "sample_info") {
+    colnames(exp) <- new_ids
+    SummarizedExperiment::colData(exp) <- stored_data
+  } else {
+    rownames(exp) <- new_ids
+    SummarizedExperiment::rowData(exp) <- stored_data
+  }
+
+  exp
+}

--- a/R/dplyr-utils.R
+++ b/R/dplyr-utils.R
@@ -34,15 +34,30 @@ is_tidy_container <- function(exp) {
   is_experiment(exp) || methods::is(exp, "SummarizedExperiment")
 }
 
+#' Get the identifier column used by a tidy manipulation verb
+#'
+#' @param exp An [experiment()] or `SummarizedExperiment` object.
+#' @param id_column Either `"sample"` or `"variable"`.
+#'
+#' @return `id_column` for an [experiment()] object, or its dot-prefixed virtual
+#'   equivalent for a `SummarizedExperiment` object.
+#' @noRd
+tidy_id_column <- function(exp, id_column) {
+  if (methods::is(exp, "SummarizedExperiment")) {
+    paste0(".", id_column)
+  } else {
+    id_column
+  }
+}
+
 #' Extract metadata for a tidy manipulation verb
 #'
 #' For `SummarizedExperiment` objects, row or column names are exposed as a
-#' transient `variable` or `sample` column when that column is not already
-#' stored in `rowData` or `colData`.
+#' transient `.variable` or `.sample` column.
 #'
 #' @param exp An [experiment()] or `SummarizedExperiment` object.
 #' @param info_field Either `"sample_info"` or `"var_info"`.
-#' @param id_column Either `"sample"` or `"variable"`.
+#' @param id_column The physical or virtual identifier column.
 #'
 #' @return A tibble containing the requested metadata and identifier column.
 #' @noRd
@@ -58,13 +73,26 @@ tidy_info_data <- function(exp, info_field, id_column) {
   }
   data <- tibble::as_tibble(data)
 
-  if (!id_column %in% colnames(data)) {
-    ids <- if (info_field == "sample_info") colnames(exp) else rownames(exp)
-    if (is.null(ids)) {
-      ids <- as.character(seq_len(nrow(data)))
+  if (id_column %in% colnames(data)) {
+    data_name <- if (info_field == "sample_info") {
+      "colData(exp)"
+    } else {
+      "rowData(exp)"
     }
-    data <- dplyr::mutate(data, "{id_column}" := ids, .before = 1)
+    cli::cli_abort(
+      c(
+        "Column {.field {id_column}} in `{data_name}` is reserved for dimension names.",
+        "i" = "Rename the metadata column before using tidy manipulation verbs."
+      ),
+      call = NULL
+    )
   }
+
+  ids <- if (info_field == "sample_info") colnames(exp) else rownames(exp)
+  if (is.null(ids)) {
+    ids <- as.character(seq_len(nrow(data)))
+  }
+  data <- dplyr::mutate(data, "{id_column}" := ids, .before = 1)
 
   data
 }
@@ -74,7 +102,7 @@ tidy_info_data <- function(exp, info_field, id_column) {
 #' @param exp A `SummarizedExperiment` object.
 #' @param new_data A data frame containing updated metadata.
 #' @param info_field Either `"sample_info"` or `"var_info"`.
-#' @param id_column Either `"sample"` or `"variable"`.
+#' @param id_column Either `".sample"` or `".variable"`.
 #' @param subset Whether to subset and reorder the corresponding dimension.
 #'
 #' @return An updated object of the same class as `exp`.
@@ -86,12 +114,6 @@ update_se_info <- function(
   id_column,
   subset = FALSE
 ) {
-  original_data <- if (info_field == "sample_info") {
-    SummarizedExperiment::colData(exp)
-  } else {
-    SummarizedExperiment::rowData(exp)
-  }
-  id_is_stored <- id_column %in% colnames(original_data)
   new_ids <- new_data[[id_column]]
 
   if (isTRUE(subset)) {
@@ -104,10 +126,7 @@ update_se_info <- function(
     }
   }
 
-  stored_data <- new_data
-  if (!id_is_stored) {
-    stored_data <- dplyr::select(stored_data, -dplyr::all_of(id_column))
-  }
+  stored_data <- dplyr::select(new_data, -dplyr::all_of(id_column))
   stored_data <- S4Vectors::DataFrame(stored_data, row.names = new_ids)
 
   if (info_field == "sample_info") {

--- a/R/dplyr-utils.R
+++ b/R/dplyr-utils.R
@@ -50,6 +50,48 @@ tidy_id_column <- function(exp, id_column) {
   }
 }
 
+#' Get the internal row-position column used by tidy manipulation verbs
+#'
+#' @return A reserved column name used to preserve exact SE dimension
+#'   positions, including when dimension names are duplicated.
+#' @noRd
+tidy_position_column <- function() {
+  "..glyexp_position.."
+}
+
+#' Abort when a tidy operation creates a reserved column
+#'
+#' @param column A reserved column name.
+#' @param data_name The user-facing metadata name.
+#'
+#' @return This function does not return.
+#' @noRd
+abort_reserved_tidy_column <- function(column, data_name) {
+  cli::cli_abort(
+    c(
+      "Column {.field {column}} in `{data_name}` is reserved for dimension names.",
+      "i" = "Choose a different metadata column name."
+    ),
+    call = NULL
+  )
+}
+
+#' Check that a tidy operation did not create reserved columns
+#'
+#' @param data A data frame to check.
+#' @param reserved_columns Reserved column names.
+#' @param data_name The user-facing metadata name.
+#'
+#' @return `data`, invisibly.
+#' @noRd
+check_reserved_tidy_columns <- function(data, reserved_columns, data_name) {
+  reserved_column <- intersect(reserved_columns, colnames(data))[1]
+  if (!is.na(reserved_column)) {
+    abort_reserved_tidy_column(reserved_column, data_name)
+  }
+  invisible(data)
+}
+
 #' Extract metadata for a tidy manipulation verb
 #'
 #' For `SummarizedExperiment` objects, row or column names are exposed as a
@@ -73,26 +115,30 @@ tidy_info_data <- function(exp, info_field, id_column) {
   }
   data <- tibble::as_tibble(data)
 
-  if (id_column %in% colnames(data)) {
-    data_name <- if (info_field == "sample_info") {
-      "colData(exp)"
-    } else {
-      "rowData(exp)"
-    }
-    cli::cli_abort(
-      c(
-        "Column {.field {id_column}} in `{data_name}` is reserved for dimension names.",
-        "i" = "Rename the metadata column before using tidy manipulation verbs."
-      ),
-      call = NULL
-    )
+  position_column <- tidy_position_column()
+  data_name <- if (info_field == "sample_info") {
+    "colData(exp)"
+  } else {
+    "rowData(exp)"
+  }
+  reserved_column <- intersect(
+    c(id_column, position_column),
+    colnames(data)
+  )[1]
+  if (!is.na(reserved_column)) {
+    abort_reserved_tidy_column(reserved_column, data_name)
   }
 
   ids <- if (info_field == "sample_info") colnames(exp) else rownames(exp)
   if (is.null(ids)) {
     ids <- as.character(seq_len(nrow(data)))
   }
-  data <- dplyr::mutate(data, "{id_column}" := ids, .before = 1)
+  data <- dplyr::mutate(
+    data,
+    "{id_column}" := ids,
+    "{position_column}" := seq_len(nrow(data)),
+    .before = 1
+  )
 
   data
 }
@@ -115,10 +161,10 @@ update_se_info <- function(
   subset = FALSE
 ) {
   new_ids <- new_data[[id_column]]
+  position_column <- tidy_position_column()
 
   if (isTRUE(subset)) {
-    original_ids <- tidy_info_data(exp, info_field, id_column)[[id_column]]
-    indices <- match(new_ids, original_ids)
+    indices <- new_data[[position_column]]
     exp <- if (info_field == "sample_info") {
       exp[, indices, drop = FALSE]
     } else {
@@ -126,7 +172,10 @@ update_se_info <- function(
     }
   }
 
-  stored_data <- dplyr::select(new_data, -dplyr::all_of(id_column))
+  stored_data <- dplyr::select(
+    new_data,
+    -dplyr::all_of(c(id_column, position_column))
+  )
   stored_data <- S4Vectors::DataFrame(stored_data, row.names = new_ids)
 
   if (info_field == "sample_info") {

--- a/man/arrange_obs.Rd
+++ b/man/arrange_obs.Rd
@@ -29,6 +29,27 @@ This actually calls \code{dplyr::arrange()} on the sample information tibble
 with the \code{group} column,
 and then updates the expression matrix accordingly to match the new order.
 }
+\section{Identifier columns}{
+
+For an \code{\link[=experiment]{experiment()}} object, \code{sample} is a physical column in
+\code{sample_info}, and \code{variable} is a physical column in \code{var_info}.
+
+For a \code{SummarizedExperiment}, sample and variable identifiers normally live
+in \code{colnames(exp)} and \code{rownames(exp)}, rather than in
+\code{\link[SummarizedExperiment:SummarizedExperiment-class]{SummarizedExperiment::colData()}} or \code{\link[SummarizedExperiment:SummarizedExperiment-class]{SummarizedExperiment::rowData()}}.
+During tidy evaluation, these names are exposed as virtual \code{sample} and
+\code{variable} columns, so they can be referenced in the same way as the
+physical columns of an \code{\link[=experiment]{experiment()}} object. After the operation, virtual
+columns are removed from the metadata and their values are written back to
+the corresponding dimension names. They receive the same protection as the
+physical index columns.
+
+If \code{colData(exp)} already contains a \code{sample} column or \code{rowData(exp)}
+already contains a \code{variable} column, that stored column is used as the
+identifier, preserved in the metadata, and kept synchronized with the
+corresponding dimension names.
+}
+
 \examples{
 # Create a toy experiment for demonstration
 exp <- toy_experiment |>

--- a/man/arrange_obs.Rd
+++ b/man/arrange_obs.Rd
@@ -34,20 +34,19 @@ and then updates the expression matrix accordingly to match the new order.
 For an \code{\link[=experiment]{experiment()}} object, \code{sample} is a physical column in
 \code{sample_info}, and \code{variable} is a physical column in \code{var_info}.
 
-For a \code{SummarizedExperiment}, sample and variable identifiers normally live
-in \code{colnames(exp)} and \code{rownames(exp)}, rather than in
+For a \code{SummarizedExperiment}, sample and variable identifiers live in
+\code{colnames(exp)} and \code{rownames(exp)}, rather than in
 \code{\link[SummarizedExperiment:SummarizedExperiment-class]{SummarizedExperiment::colData()}} or \code{\link[SummarizedExperiment:SummarizedExperiment-class]{SummarizedExperiment::rowData()}}.
-During tidy evaluation, these names are exposed as virtual \code{sample} and
-\code{variable} columns, so they can be referenced in the same way as the
-physical columns of an \code{\link[=experiment]{experiment()}} object. After the operation, virtual
-columns are removed from the metadata and their values are written back to
-the corresponding dimension names. They receive the same protection as the
-physical index columns.
+Observation verbs expose \code{colnames(exp)} as a virtual \code{.sample} column, and
+variable verbs expose \code{rownames(exp)} as a virtual \code{.variable} column. These
+dot-prefixed names distinguish dimension identifiers from regular metadata
+columns. After the operation, the virtual column is removed and its values
+are written back to the corresponding dimension names.
 
-If \code{colData(exp)} already contains a \code{sample} column or \code{rowData(exp)}
-already contains a \code{variable} column, that stored column is used as the
-identifier, preserved in the metadata, and kept synchronized with the
-corresponding dimension names.
+Consequently, \code{sample} in \code{colData(exp)} and \code{variable} in \code{rowData(exp)}
+remain ordinary metadata columns. The names \code{.sample} and \code{.variable} are
+reserved; an input containing either name in the corresponding metadata
+raises an error rather than overwriting that column.
 }
 
 \examples{

--- a/man/arrange_obs.Rd
+++ b/man/arrange_obs.Rd
@@ -10,16 +10,17 @@ arrange_obs(exp, ...)
 arrange_var(exp, ...)
 }
 \arguments{
-\item{exp}{An \code{\link[=experiment]{experiment()}}.}
+\item{exp}{An \code{\link[=experiment]{experiment()}} or \code{SummarizedExperiment} object.}
 
 \item{...}{<\code{\link[rlang:args_data_masking]{data-masking}}> Variables to arrange by,
 passed to \code{dplyr::arrange()} internally.}
 }
 \value{
-An new \code{\link[=experiment]{experiment()}} object.
+An object of the same class as \code{exp}.
 }
 \description{
-Arrange the sample or variable information tibble of an \code{\link[=experiment]{experiment()}}.
+Arrange the sample or variable information of an \code{\link[=experiment]{experiment()}} or
+\code{SummarizedExperiment}.
 
 The same syntax as \code{dplyr::arrange()} is used.
 For example, to arrange samples by the "group" column,

--- a/man/filter_obs.Rd
+++ b/man/filter_obs.Rd
@@ -37,6 +37,27 @@ One difference between \code{filter_obs()} or \code{filter_var()} and \link[dply
 when filtering on factor columns, the unused levels are automatically dropped by default.
 This behavior can be turnt off by setting \code{.drop_levels} to FALSE.
 }
+\section{Identifier columns}{
+
+For an \code{\link[=experiment]{experiment()}} object, \code{sample} is a physical column in
+\code{sample_info}, and \code{variable} is a physical column in \code{var_info}.
+
+For a \code{SummarizedExperiment}, sample and variable identifiers normally live
+in \code{colnames(exp)} and \code{rownames(exp)}, rather than in
+\code{\link[SummarizedExperiment:SummarizedExperiment-class]{SummarizedExperiment::colData()}} or \code{\link[SummarizedExperiment:SummarizedExperiment-class]{SummarizedExperiment::rowData()}}.
+During tidy evaluation, these names are exposed as virtual \code{sample} and
+\code{variable} columns, so they can be referenced in the same way as the
+physical columns of an \code{\link[=experiment]{experiment()}} object. After the operation, virtual
+columns are removed from the metadata and their values are written back to
+the corresponding dimension names. They receive the same protection as the
+physical index columns.
+
+If \code{colData(exp)} already contains a \code{sample} column or \code{rowData(exp)}
+already contains a \code{variable} column, that stored column is used as the
+identifier, preserved in the metadata, and kept synchronized with the
+corresponding dimension names.
+}
+
 \examples{
 # Create a toy experiment for demonstration
 exp <- toy_experiment |>

--- a/man/filter_obs.Rd
+++ b/man/filter_obs.Rd
@@ -42,20 +42,19 @@ This behavior can be turnt off by setting \code{.drop_levels} to FALSE.
 For an \code{\link[=experiment]{experiment()}} object, \code{sample} is a physical column in
 \code{sample_info}, and \code{variable} is a physical column in \code{var_info}.
 
-For a \code{SummarizedExperiment}, sample and variable identifiers normally live
-in \code{colnames(exp)} and \code{rownames(exp)}, rather than in
+For a \code{SummarizedExperiment}, sample and variable identifiers live in
+\code{colnames(exp)} and \code{rownames(exp)}, rather than in
 \code{\link[SummarizedExperiment:SummarizedExperiment-class]{SummarizedExperiment::colData()}} or \code{\link[SummarizedExperiment:SummarizedExperiment-class]{SummarizedExperiment::rowData()}}.
-During tidy evaluation, these names are exposed as virtual \code{sample} and
-\code{variable} columns, so they can be referenced in the same way as the
-physical columns of an \code{\link[=experiment]{experiment()}} object. After the operation, virtual
-columns are removed from the metadata and their values are written back to
-the corresponding dimension names. They receive the same protection as the
-physical index columns.
+Observation verbs expose \code{colnames(exp)} as a virtual \code{.sample} column, and
+variable verbs expose \code{rownames(exp)} as a virtual \code{.variable} column. These
+dot-prefixed names distinguish dimension identifiers from regular metadata
+columns. After the operation, the virtual column is removed and its values
+are written back to the corresponding dimension names.
 
-If \code{colData(exp)} already contains a \code{sample} column or \code{rowData(exp)}
-already contains a \code{variable} column, that stored column is used as the
-identifier, preserved in the metadata, and kept synchronized with the
-corresponding dimension names.
+Consequently, \code{sample} in \code{colData(exp)} and \code{variable} in \code{rowData(exp)}
+remain ordinary metadata columns. The names \code{.sample} and \code{.variable} are
+reserved; an input containing either name in the corresponding metadata
+raises an error rather than overwriting that column.
 }
 
 \examples{

--- a/man/filter_obs.Rd
+++ b/man/filter_obs.Rd
@@ -10,7 +10,7 @@ filter_obs(exp, ..., .drop_levels = TRUE)
 filter_var(exp, ..., .drop_levels = TRUE)
 }
 \arguments{
-\item{exp}{An \code{\link[=experiment]{experiment()}}.}
+\item{exp}{An \code{\link[=experiment]{experiment()}} or \code{SummarizedExperiment} object.}
 
 \item{...}{<\code{\link[rlang:args_data_masking]{data-masking}}> Expression to filter samples or variables.
 passed to \code{\link[dplyr:filter]{dplyr::filter()}} internally.}
@@ -19,10 +19,11 @@ passed to \code{\link[dplyr:filter]{dplyr::filter()}} internally.}
 referenced in the filtering expressions.}
 }
 \value{
-An new \code{\link[=experiment]{experiment()}} object.
+An object of the same class as \code{exp}.
 }
 \description{
-Getting a subset of an \code{\link[=experiment]{experiment()}} by filtering samples or variables.
+Getting a subset of an \code{\link[=experiment]{experiment()}} or \code{SummarizedExperiment} by filtering
+samples or variables.
 
 The same syntax as \code{\link[dplyr:filter]{dplyr::filter()}} is used.
 For example, to get a subset of an experiment keeping only "HC" samples,

--- a/man/left_join_obs.Rd
+++ b/man/left_join_obs.Rd
@@ -62,6 +62,27 @@ experiment object assumptions.
 new observations to the experiment.
 }
 }
+\section{Identifier columns}{
+
+For an \code{\link[=experiment]{experiment()}} object, \code{sample} is a physical column in
+\code{sample_info}, and \code{variable} is a physical column in \code{var_info}.
+
+For a \code{SummarizedExperiment}, sample and variable identifiers normally live
+in \code{colnames(exp)} and \code{rownames(exp)}, rather than in
+\code{\link[SummarizedExperiment:SummarizedExperiment-class]{SummarizedExperiment::colData()}} or \code{\link[SummarizedExperiment:SummarizedExperiment-class]{SummarizedExperiment::rowData()}}.
+During tidy evaluation, these names are exposed as virtual \code{sample} and
+\code{variable} columns, so they can be referenced in the same way as the
+physical columns of an \code{\link[=experiment]{experiment()}} object. After the operation, virtual
+columns are removed from the metadata and their values are written back to
+the corresponding dimension names. They receive the same protection as the
+physical index columns.
+
+If \code{colData(exp)} already contains a \code{sample} column or \code{rowData(exp)}
+already contains a \code{variable} column, that stored column is used as the
+identifier, preserved in the metadata, and kept synchronized with the
+corresponding dimension names.
+}
+
 \examples{
 library(dplyr)
 library(tibble)

--- a/man/left_join_obs.Rd
+++ b/man/left_join_obs.Rd
@@ -67,20 +67,19 @@ new observations to the experiment.
 For an \code{\link[=experiment]{experiment()}} object, \code{sample} is a physical column in
 \code{sample_info}, and \code{variable} is a physical column in \code{var_info}.
 
-For a \code{SummarizedExperiment}, sample and variable identifiers normally live
-in \code{colnames(exp)} and \code{rownames(exp)}, rather than in
+For a \code{SummarizedExperiment}, sample and variable identifiers live in
+\code{colnames(exp)} and \code{rownames(exp)}, rather than in
 \code{\link[SummarizedExperiment:SummarizedExperiment-class]{SummarizedExperiment::colData()}} or \code{\link[SummarizedExperiment:SummarizedExperiment-class]{SummarizedExperiment::rowData()}}.
-During tidy evaluation, these names are exposed as virtual \code{sample} and
-\code{variable} columns, so they can be referenced in the same way as the
-physical columns of an \code{\link[=experiment]{experiment()}} object. After the operation, virtual
-columns are removed from the metadata and their values are written back to
-the corresponding dimension names. They receive the same protection as the
-physical index columns.
+Observation verbs expose \code{colnames(exp)} as a virtual \code{.sample} column, and
+variable verbs expose \code{rownames(exp)} as a virtual \code{.variable} column. These
+dot-prefixed names distinguish dimension identifiers from regular metadata
+columns. After the operation, the virtual column is removed and its values
+are written back to the corresponding dimension names.
 
-If \code{colData(exp)} already contains a \code{sample} column or \code{rowData(exp)}
-already contains a \code{variable} column, that stored column is used as the
-identifier, preserved in the metadata, and kept synchronized with the
-corresponding dimension names.
+Consequently, \code{sample} in \code{colData(exp)} and \code{variable} in \code{rowData(exp)}
+remain ordinary metadata columns. The names \code{.sample} and \code{.variable} are
+reserved; an input containing either name in the corresponding metadata
+raises an error rather than overwriting that column.
 }
 
 \examples{

--- a/man/left_join_obs.Rd
+++ b/man/left_join_obs.Rd
@@ -28,7 +28,7 @@ semi_join_var(exp, y, by = NULL, ...)
 anti_join_var(exp, y, by = NULL, ...)
 }
 \arguments{
-\item{exp}{An \code{\link[=experiment]{experiment()}}.}
+\item{exp}{An \code{\link[=experiment]{experiment()}} or \code{SummarizedExperiment} object.}
 
 \item{y}{A data frame to join to \code{sample_info} or \code{var_info}.}
 
@@ -39,15 +39,18 @@ character vector of variables to join by. See \code{\link[dplyr:mutate-joins]{dp
 except \code{relationship} which is locked to "many-to-one".}
 }
 \value{
-A new \code{\link[=experiment]{experiment()}} object with updated sample or variable information.
+An object of the same class as \code{exp}, with updated sample or variable
+information.
 }
 \description{
 These functions allow you to join additional data to the sample information
-or variable information of an \code{\link[=experiment]{experiment()}}. They work similarly to
+or variable information of an \code{\link[=experiment]{experiment()}} or \code{SummarizedExperiment}.
+They work similarly to
 \code{\link[dplyr:mutate-joins]{dplyr::left_join()}}, \code{\link[dplyr:mutate-joins]{dplyr::inner_join()}}, \code{\link[dplyr:filter-joins]{dplyr::semi_join()}}, and
-\code{\link[dplyr:filter-joins]{dplyr::anti_join()}}, but are designed to work with experiment objects.
+\code{\link[dplyr:filter-joins]{dplyr::anti_join()}}, while keeping assay dimensions synchronized with the
+joined metadata.
 
-After joining, the \code{expr_mat} is automatically updated to reflect any
+After joining, the assay dimensions are automatically updated to reflect any
 changes in the number of samples or variables.
 
 \strong{Important Notes:}

--- a/man/mutate_obs.Rd
+++ b/man/mutate_obs.Rd
@@ -28,9 +28,8 @@ use \code{mutate_obs(exp, new_column = value)}.
 This actually calls \code{dplyr::mutate()} on the sample information tibble
 with \code{new_column = value}.
 
-If the \code{sample} column in \code{sample_info} or the \code{variable} column in \code{var_info}
-is to be modified, the new column must be unique,
-otherwise an error is thrown.
+If an identifier column is modified, its new values must be unique;
+otherwise, an error is thrown.
 The assay column names or row names will be updated accordingly.
 }
 \section{Identifier columns}{
@@ -38,20 +37,19 @@ The assay column names or row names will be updated accordingly.
 For an \code{\link[=experiment]{experiment()}} object, \code{sample} is a physical column in
 \code{sample_info}, and \code{variable} is a physical column in \code{var_info}.
 
-For a \code{SummarizedExperiment}, sample and variable identifiers normally live
-in \code{colnames(exp)} and \code{rownames(exp)}, rather than in
+For a \code{SummarizedExperiment}, sample and variable identifiers live in
+\code{colnames(exp)} and \code{rownames(exp)}, rather than in
 \code{\link[SummarizedExperiment:SummarizedExperiment-class]{SummarizedExperiment::colData()}} or \code{\link[SummarizedExperiment:SummarizedExperiment-class]{SummarizedExperiment::rowData()}}.
-During tidy evaluation, these names are exposed as virtual \code{sample} and
-\code{variable} columns, so they can be referenced in the same way as the
-physical columns of an \code{\link[=experiment]{experiment()}} object. After the operation, virtual
-columns are removed from the metadata and their values are written back to
-the corresponding dimension names. They receive the same protection as the
-physical index columns.
+Observation verbs expose \code{colnames(exp)} as a virtual \code{.sample} column, and
+variable verbs expose \code{rownames(exp)} as a virtual \code{.variable} column. These
+dot-prefixed names distinguish dimension identifiers from regular metadata
+columns. After the operation, the virtual column is removed and its values
+are written back to the corresponding dimension names.
 
-If \code{colData(exp)} already contains a \code{sample} column or \code{rowData(exp)}
-already contains a \code{variable} column, that stored column is used as the
-identifier, preserved in the metadata, and kept synchronized with the
-corresponding dimension names.
+Consequently, \code{sample} in \code{colData(exp)} and \code{variable} in \code{rowData(exp)}
+remain ordinary metadata columns. The names \code{.sample} and \code{.variable} are
+reserved; an input containing either name in the corresponding metadata
+raises an error rather than overwriting that column.
 }
 
 \examples{
@@ -86,5 +84,10 @@ get_expr_mat(new_exp)
 new_exp <- mutate_var(exp, variable = c("VI", "VII", "VIII", "VIV"))
 get_var_info(new_exp)
 get_expr_mat(new_exp)
+
+# SummarizedExperiment identifiers use virtual dot-prefixed columns
+se <- as_se(toy_experiment)
+mutate_obs(se, .sample = paste0("new_", .sample))
+mutate_var(se, .variable = paste0("new_", .variable))
 
 }

--- a/man/mutate_obs.Rd
+++ b/man/mutate_obs.Rd
@@ -10,16 +10,17 @@ mutate_obs(exp, ...)
 mutate_var(exp, ...)
 }
 \arguments{
-\item{exp}{An \code{\link[=experiment]{experiment()}}.}
+\item{exp}{An \code{\link[=experiment]{experiment()}} or \code{SummarizedExperiment} object.}
 
 \item{...}{<\code{\link[rlang:args_data_masking]{data-masking}}> Name-value pairs,
 passed to \code{dplyr::mutate()} internally.}
 }
 \value{
-An new \code{\link[=experiment]{experiment()}} object.
+An object of the same class as \code{exp}.
 }
 \description{
-Mutate the sample or variable information tibble of an \code{\link[=experiment]{experiment()}}.
+Mutate the sample or variable information of an \code{\link[=experiment]{experiment()}} or
+\code{SummarizedExperiment}.
 
 The same syntax as \code{dplyr::mutate()} is used.
 For example, to add a new column to the sample information tibble,
@@ -30,7 +31,7 @@ with \code{new_column = value}.
 If the \code{sample} column in \code{sample_info} or the \code{variable} column in \code{var_info}
 is to be modified, the new column must be unique,
 otherwise an error is thrown.
-The column names or row names of \code{expr_mat} will be updated accordingly.
+The assay column names or row names will be updated accordingly.
 }
 \examples{
 # Create a toy experiment for demonstration

--- a/man/mutate_obs.Rd
+++ b/man/mutate_obs.Rd
@@ -33,6 +33,27 @@ is to be modified, the new column must be unique,
 otherwise an error is thrown.
 The assay column names or row names will be updated accordingly.
 }
+\section{Identifier columns}{
+
+For an \code{\link[=experiment]{experiment()}} object, \code{sample} is a physical column in
+\code{sample_info}, and \code{variable} is a physical column in \code{var_info}.
+
+For a \code{SummarizedExperiment}, sample and variable identifiers normally live
+in \code{colnames(exp)} and \code{rownames(exp)}, rather than in
+\code{\link[SummarizedExperiment:SummarizedExperiment-class]{SummarizedExperiment::colData()}} or \code{\link[SummarizedExperiment:SummarizedExperiment-class]{SummarizedExperiment::rowData()}}.
+During tidy evaluation, these names are exposed as virtual \code{sample} and
+\code{variable} columns, so they can be referenced in the same way as the
+physical columns of an \code{\link[=experiment]{experiment()}} object. After the operation, virtual
+columns are removed from the metadata and their values are written back to
+the corresponding dimension names. They receive the same protection as the
+physical index columns.
+
+If \code{colData(exp)} already contains a \code{sample} column or \code{rowData(exp)}
+already contains a \code{variable} column, that stored column is used as the
+identifier, preserved in the metadata, and kept synchronized with the
+corresponding dimension names.
+}
+
 \examples{
 # Create a toy experiment for demonstration
 exp <- toy_experiment |>

--- a/man/rename_obs.Rd
+++ b/man/rename_obs.Rd
@@ -35,20 +35,19 @@ to the expression matrix.
 For an \code{\link[=experiment]{experiment()}} object, \code{sample} is a physical column in
 \code{sample_info}, and \code{variable} is a physical column in \code{var_info}.
 
-For a \code{SummarizedExperiment}, sample and variable identifiers normally live
-in \code{colnames(exp)} and \code{rownames(exp)}, rather than in
+For a \code{SummarizedExperiment}, sample and variable identifiers live in
+\code{colnames(exp)} and \code{rownames(exp)}, rather than in
 \code{\link[SummarizedExperiment:SummarizedExperiment-class]{SummarizedExperiment::colData()}} or \code{\link[SummarizedExperiment:SummarizedExperiment-class]{SummarizedExperiment::rowData()}}.
-During tidy evaluation, these names are exposed as virtual \code{sample} and
-\code{variable} columns, so they can be referenced in the same way as the
-physical columns of an \code{\link[=experiment]{experiment()}} object. After the operation, virtual
-columns are removed from the metadata and their values are written back to
-the corresponding dimension names. They receive the same protection as the
-physical index columns.
+Observation verbs expose \code{colnames(exp)} as a virtual \code{.sample} column, and
+variable verbs expose \code{rownames(exp)} as a virtual \code{.variable} column. These
+dot-prefixed names distinguish dimension identifiers from regular metadata
+columns. After the operation, the virtual column is removed and its values
+are written back to the corresponding dimension names.
 
-If \code{colData(exp)} already contains a \code{sample} column or \code{rowData(exp)}
-already contains a \code{variable} column, that stored column is used as the
-identifier, preserved in the metadata, and kept synchronized with the
-corresponding dimension names.
+Consequently, \code{sample} in \code{colData(exp)} and \code{variable} in \code{rowData(exp)}
+remain ordinary metadata columns. The names \code{.sample} and \code{.variable} are
+reserved; an input containing either name in the corresponding metadata
+raises an error rather than overwriting that column.
 }
 
 \examples{

--- a/man/rename_obs.Rd
+++ b/man/rename_obs.Rd
@@ -10,17 +10,17 @@ rename_obs(exp, ...)
 rename_var(exp, ...)
 }
 \arguments{
-\item{exp}{An \code{\link[=experiment]{experiment()}}.}
+\item{exp}{An \code{\link[=experiment]{experiment()}} or \code{SummarizedExperiment} object.}
 
 \item{...}{<\code{\link[rlang:args_data_masking]{data-masking}}> Name pairs to rename.
 Use \code{new_name = old_name} to rename columns.}
 }
 \value{
-An new \code{\link[=experiment]{experiment()}} object.
+An object of the same class as \code{exp}.
 }
 \description{
 These two functions provide a way to rename columns in the sample or variable
-information tibble of an \code{\link[=experiment]{experiment()}}.
+information of an \code{\link[=experiment]{experiment()}} or \code{SummarizedExperiment}.
 
 The same syntax as \code{dplyr::rename()} is used.
 For example, to rename the "group" column in the sample information tibble to "condition",

--- a/man/rename_obs.Rd
+++ b/man/rename_obs.Rd
@@ -30,6 +30,27 @@ as well as the "variable" column in the variable information tibble.
 These two columns are used to link the sample or variable information tibble
 to the expression matrix.
 }
+\section{Identifier columns}{
+
+For an \code{\link[=experiment]{experiment()}} object, \code{sample} is a physical column in
+\code{sample_info}, and \code{variable} is a physical column in \code{var_info}.
+
+For a \code{SummarizedExperiment}, sample and variable identifiers normally live
+in \code{colnames(exp)} and \code{rownames(exp)}, rather than in
+\code{\link[SummarizedExperiment:SummarizedExperiment-class]{SummarizedExperiment::colData()}} or \code{\link[SummarizedExperiment:SummarizedExperiment-class]{SummarizedExperiment::rowData()}}.
+During tidy evaluation, these names are exposed as virtual \code{sample} and
+\code{variable} columns, so they can be referenced in the same way as the
+physical columns of an \code{\link[=experiment]{experiment()}} object. After the operation, virtual
+columns are removed from the metadata and their values are written back to
+the corresponding dimension names. They receive the same protection as the
+physical index columns.
+
+If \code{colData(exp)} already contains a \code{sample} column or \code{rowData(exp)}
+already contains a \code{variable} column, that stored column is used as the
+identifier, preserved in the metadata, and kept synchronized with the
+corresponding dimension names.
+}
+
 \examples{
 toy_exp <- toy_experiment
 toy_exp

--- a/man/select_obs.Rd
+++ b/man/select_obs.Rd
@@ -45,20 +45,19 @@ If you encounter package conflicts, use the following code to resolve them:
 For an \code{\link[=experiment]{experiment()}} object, \code{sample} is a physical column in
 \code{sample_info}, and \code{variable} is a physical column in \code{var_info}.
 
-For a \code{SummarizedExperiment}, sample and variable identifiers normally live
-in \code{colnames(exp)} and \code{rownames(exp)}, rather than in
+For a \code{SummarizedExperiment}, sample and variable identifiers live in
+\code{colnames(exp)} and \code{rownames(exp)}, rather than in
 \code{\link[SummarizedExperiment:SummarizedExperiment-class]{SummarizedExperiment::colData()}} or \code{\link[SummarizedExperiment:SummarizedExperiment-class]{SummarizedExperiment::rowData()}}.
-During tidy evaluation, these names are exposed as virtual \code{sample} and
-\code{variable} columns, so they can be referenced in the same way as the
-physical columns of an \code{\link[=experiment]{experiment()}} object. After the operation, virtual
-columns are removed from the metadata and their values are written back to
-the corresponding dimension names. They receive the same protection as the
-physical index columns.
+Observation verbs expose \code{colnames(exp)} as a virtual \code{.sample} column, and
+variable verbs expose \code{rownames(exp)} as a virtual \code{.variable} column. These
+dot-prefixed names distinguish dimension identifiers from regular metadata
+columns. After the operation, the virtual column is removed and its values
+are written back to the corresponding dimension names.
 
-If \code{colData(exp)} already contains a \code{sample} column or \code{rowData(exp)}
-already contains a \code{variable} column, that stored column is used as the
-identifier, preserved in the metadata, and kept synchronized with the
-corresponding dimension names.
+Consequently, \code{sample} in \code{colData(exp)} and \code{variable} in \code{rowData(exp)}
+remain ordinary metadata columns. The names \code{.sample} and \code{.variable} are
+reserved; an input containing either name in the corresponding metadata
+raises an error rather than overwriting that column.
 }
 
 \examples{

--- a/man/select_obs.Rd
+++ b/man/select_obs.Rd
@@ -40,6 +40,27 @@ If you encounter package conflicts, use the following code to resolve them:
 \if{html}{\out{<div class="sourceCode R">}}\preformatted{conflicted::conflicts_prefer(glyexp::select_var)
 }\if{html}{\out{</div>}}
 }
+\section{Identifier columns}{
+
+For an \code{\link[=experiment]{experiment()}} object, \code{sample} is a physical column in
+\code{sample_info}, and \code{variable} is a physical column in \code{var_info}.
+
+For a \code{SummarizedExperiment}, sample and variable identifiers normally live
+in \code{colnames(exp)} and \code{rownames(exp)}, rather than in
+\code{\link[SummarizedExperiment:SummarizedExperiment-class]{SummarizedExperiment::colData()}} or \code{\link[SummarizedExperiment:SummarizedExperiment-class]{SummarizedExperiment::rowData()}}.
+During tidy evaluation, these names are exposed as virtual \code{sample} and
+\code{variable} columns, so they can be referenced in the same way as the
+physical columns of an \code{\link[=experiment]{experiment()}} object. After the operation, virtual
+columns are removed from the metadata and their values are written back to
+the corresponding dimension names. They receive the same protection as the
+physical index columns.
+
+If \code{colData(exp)} already contains a \code{sample} column or \code{rowData(exp)}
+already contains a \code{variable} column, that stored column is used as the
+identifier, preserved in the metadata, and kept synchronized with the
+corresponding dimension names.
+}
+
 \examples{
 toy_exp <- toy_experiment
 

--- a/man/select_obs.Rd
+++ b/man/select_obs.Rd
@@ -10,17 +10,18 @@ select_obs(exp, ...)
 select_var(exp, ...)
 }
 \arguments{
-\item{exp}{An \code{\link[=experiment]{experiment()}}.}
+\item{exp}{An \code{\link[=experiment]{experiment()}} or \code{SummarizedExperiment} object.}
 
 \item{...}{<\code{\link[rlang:args_data_masking]{data-masking}}> Column names to select.
 If empty, all columns except the \code{sample} or \code{variable} column will be discarded.}
 }
 \value{
-An new \code{\link[=experiment]{experiment()}} object.
+An object of the same class as \code{exp}.
 }
 \description{
 These two functions provide a way to trimming down the sample or variable information tibble
-of an \code{\link[=experiment]{experiment()}} to only the columns of interest.
+of an \code{\link[=experiment]{experiment()}} or \code{SummarizedExperiment} to only the columns of
+interest.
 
 The same syntax as \code{dplyr::select()} is used.
 For example, to get a new \code{\link[=experiment]{experiment()}} with only the "sample" and "group"

--- a/man/slice_obs.Rd
+++ b/man/slice_obs.Rd
@@ -81,6 +81,27 @@ and update the expression matrix accordingly to match the new selection.
 \item \code{slice_min_obs()} and \code{slice_min_var()}: Select rows with lowest values
 }
 }
+\section{Identifier columns}{
+
+For an \code{\link[=experiment]{experiment()}} object, \code{sample} is a physical column in
+\code{sample_info}, and \code{variable} is a physical column in \code{var_info}.
+
+For a \code{SummarizedExperiment}, sample and variable identifiers normally live
+in \code{colnames(exp)} and \code{rownames(exp)}, rather than in
+\code{\link[SummarizedExperiment:SummarizedExperiment-class]{SummarizedExperiment::colData()}} or \code{\link[SummarizedExperiment:SummarizedExperiment-class]{SummarizedExperiment::rowData()}}.
+During tidy evaluation, these names are exposed as virtual \code{sample} and
+\code{variable} columns, so they can be referenced in the same way as the
+physical columns of an \code{\link[=experiment]{experiment()}} object. After the operation, virtual
+columns are removed from the metadata and their values are written back to
+the corresponding dimension names. They receive the same protection as the
+physical index columns.
+
+If \code{colData(exp)} already contains a \code{sample} column or \code{rowData(exp)}
+already contains a \code{variable} column, that stored column is used as the
+identifier, preserved in the metadata, and kept synchronized with the
+corresponding dimension names.
+}
+
 \examples{
 # Create a toy experiment for demonstration
 exp <- toy_experiment |>

--- a/man/slice_obs.Rd
+++ b/man/slice_obs.Rd
@@ -40,7 +40,7 @@ slice_min_obs(exp, order_by, ..., n, prop, with_ties = TRUE, na_rm = FALSE)
 slice_min_var(exp, order_by, ..., n, prop, with_ties = TRUE, na_rm = FALSE)
 }
 \arguments{
-\item{exp}{An \code{\link[=experiment]{experiment()}}.}
+\item{exp}{An \code{\link[=experiment]{experiment()}} or \code{SummarizedExperiment} object.}
 
 \item{...}{<\code{\link[rlang:args_data_masking]{data-masking}}> For \verb{slice_*()},
 integer row positions. For \code{slice_max()} and \code{slice_min()}, variables to
@@ -63,10 +63,11 @@ and \code{slice_min()}, the proportion of rows to select.}
 \item{na_rm}{For \code{slice_max()} and \code{slice_min()}, should missing values be removed?}
 }
 \value{
-A new \code{\link[=experiment]{experiment()}} object.
+An object of the same class as \code{exp}.
 }
 \description{
-Slice the sample or variable information tibble of an \code{\link[=experiment]{experiment()}}.
+Slice the sample or variable information of an \code{\link[=experiment]{experiment()}} or
+\code{SummarizedExperiment}.
 
 These functions provide row-wise slicing operations similar to dplyr's slice functions.
 They select rows by position or based on values in specified columns,

--- a/man/slice_obs.Rd
+++ b/man/slice_obs.Rd
@@ -86,20 +86,19 @@ and update the expression matrix accordingly to match the new selection.
 For an \code{\link[=experiment]{experiment()}} object, \code{sample} is a physical column in
 \code{sample_info}, and \code{variable} is a physical column in \code{var_info}.
 
-For a \code{SummarizedExperiment}, sample and variable identifiers normally live
-in \code{colnames(exp)} and \code{rownames(exp)}, rather than in
+For a \code{SummarizedExperiment}, sample and variable identifiers live in
+\code{colnames(exp)} and \code{rownames(exp)}, rather than in
 \code{\link[SummarizedExperiment:SummarizedExperiment-class]{SummarizedExperiment::colData()}} or \code{\link[SummarizedExperiment:SummarizedExperiment-class]{SummarizedExperiment::rowData()}}.
-During tidy evaluation, these names are exposed as virtual \code{sample} and
-\code{variable} columns, so they can be referenced in the same way as the
-physical columns of an \code{\link[=experiment]{experiment()}} object. After the operation, virtual
-columns are removed from the metadata and their values are written back to
-the corresponding dimension names. They receive the same protection as the
-physical index columns.
+Observation verbs expose \code{colnames(exp)} as a virtual \code{.sample} column, and
+variable verbs expose \code{rownames(exp)} as a virtual \code{.variable} column. These
+dot-prefixed names distinguish dimension identifiers from regular metadata
+columns. After the operation, the virtual column is removed and its values
+are written back to the corresponding dimension names.
 
-If \code{colData(exp)} already contains a \code{sample} column or \code{rowData(exp)}
-already contains a \code{variable} column, that stored column is used as the
-identifier, preserved in the metadata, and kept synchronized with the
-corresponding dimension names.
+Consequently, \code{sample} in \code{colData(exp)} and \code{variable} in \code{rowData(exp)}
+remain ordinary metadata columns. The names \code{.sample} and \code{.variable} are
+reserved; an input containing either name in the corresponding metadata
+raises an error rather than overwriting that column.
 }
 
 \examples{

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -38,6 +38,13 @@ create_test_exp <- function(
   )
 }
 
+create_test_se <- function(samples, variables) {
+  exp <- create_test_exp(samples, variables)
+  se <- as_se(exp)
+  S4Vectors::metadata(se)$marker <- "preserved"
+  se
+}
+
 create_test_exp_2 <- function() {
   expr_mat <- create_expr_mat(c("S1", "S2", "S3"), c("V1", "V2", "V3"))
   sample_info <- tibble::tibble(

--- a/tests/testthat/test-dplyr-arrange.R
+++ b/tests/testthat/test-dplyr-arrange.R
@@ -21,6 +21,20 @@ test_that("arranging variables works", {
   expect_equal(rownames(arranged_exp$expr_mat), c("V2", "V1", "V3"))
 })
 
+test_that("arrange verbs support SummarizedExperiment", {
+  se <- create_test_se(c("S1", "S2", "S3"), c("V1", "V2", "V3")) |>
+    mutate_obs(score = c(2, 3, 1)) |>
+    mutate_var(score = c(1, 3, 2))
+
+  result <- se |>
+    arrange_obs(score) |>
+    arrange_var(dplyr::desc(score))
+
+  expect_identical(colnames(result), c("S3", "S1", "S2"))
+  expect_identical(rownames(result), c("V2", "V3", "V1"))
+  expect_identical(S4Vectors::metadata(result)$marker, "preserved")
+})
+
 
 test_that("arranging by multiple columns works", {
   exp <- create_test_exp(c("S1", "S2", "S3", "S4"), c("V1", "V2"))

--- a/tests/testthat/test-dplyr-arrange.R
+++ b/tests/testthat/test-dplyr-arrange.R
@@ -27,8 +27,8 @@ test_that("arrange verbs support SummarizedExperiment", {
     mutate_var(score = c(1, 3, 2))
 
   result <- se |>
-    arrange_obs(score) |>
-    arrange_var(dplyr::desc(score))
+    arrange_obs(score, .sample) |>
+    arrange_var(dplyr::desc(score), .variable)
 
   expect_identical(colnames(result), c("S3", "S1", "S2"))
   expect_identical(rownames(result), c("V2", "V3", "V1"))

--- a/tests/testthat/test-dplyr-filter.R
+++ b/tests/testthat/test-dplyr-filter.R
@@ -21,6 +21,47 @@ test_that("filtering works", {
   expect_equal(exp2$var_info, create_var_info(c("V1", "V2")))
 })
 
+test_that("filter verbs support SummarizedExperiment", {
+  se <- create_test_se(c("S1", "S2", "S3"), c("V1", "V2", "V3"))
+
+  result <- se |>
+    filter_obs(group == "A") |>
+    filter_var(type == "B")
+
+  expect_s4_class(result, "SummarizedExperiment")
+  expect_identical(colnames(result), c("S1", "S2", "S3"))
+  expect_identical(rownames(result), c("V1", "V2", "V3"))
+  expect_identical(S4Vectors::metadata(result)$marker, "preserved")
+})
+
+test_that("filtering SummarizedExperiment preserves assays and stored IDs", {
+  se <- create_test_se(c("S1", "S2", "S3"), c("V1", "V2", "V3"))
+  SummarizedExperiment::assays(se)$scaled <-
+    SummarizedExperiment::assay(se) * 10
+  SummarizedExperiment::colData(se)$sample <- colnames(se)
+  SummarizedExperiment::rowData(se)$variable <- rownames(se)
+
+  result <- se |>
+    filter_obs(sample != "S2") |>
+    filter_var(variable != "V2")
+
+  expect_identical(
+    names(SummarizedExperiment::assays(result)),
+    c("abundance", "scaled")
+  )
+  expect_identical(colnames(result), c("S1", "S3"))
+  expect_identical(rownames(result), c("V1", "V3"))
+  expect_identical(SummarizedExperiment::colData(result)$sample, c("S1", "S3"))
+  expect_identical(
+    SummarizedExperiment::rowData(result)$variable,
+    c("V1", "V3")
+  )
+  expect_identical(
+    SummarizedExperiment::assay(result, "scaled"),
+    SummarizedExperiment::assay(result, "abundance") * 10
+  )
+})
+
 
 test_that("filtering to no samples/variables results in an empty experiment", {
   exp <- create_test_exp(c("S1", "S2", "S3"), c("V1", "V2", "V3"))

--- a/tests/testthat/test-dplyr-filter.R
+++ b/tests/testthat/test-dplyr-filter.R
@@ -34,16 +34,16 @@ test_that("filter verbs support SummarizedExperiment", {
   expect_identical(S4Vectors::metadata(result)$marker, "preserved")
 })
 
-test_that("filtering SummarizedExperiment preserves assays and stored IDs", {
+test_that("filtering SummarizedExperiment uses virtual identifiers", {
   se <- create_test_se(c("S1", "S2", "S3"), c("V1", "V2", "V3"))
   SummarizedExperiment::assays(se)$scaled <-
     SummarizedExperiment::assay(se) * 10
-  SummarizedExperiment::colData(se)$sample <- colnames(se)
-  SummarizedExperiment::rowData(se)$variable <- rownames(se)
+  SummarizedExperiment::colData(se)$sample <- c("A", "B", "C")
+  SummarizedExperiment::rowData(se)$variable <- c("X", "Y", "Z")
 
   result <- se |>
-    filter_obs(sample != "S2") |>
-    filter_var(variable != "V2")
+    filter_obs(.sample != "S2") |>
+    filter_var(.variable != "V2")
 
   expect_identical(
     names(SummarizedExperiment::assays(result)),
@@ -51,10 +51,10 @@ test_that("filtering SummarizedExperiment preserves assays and stored IDs", {
   )
   expect_identical(colnames(result), c("S1", "S3"))
   expect_identical(rownames(result), c("V1", "V3"))
-  expect_identical(SummarizedExperiment::colData(result)$sample, c("S1", "S3"))
+  expect_identical(SummarizedExperiment::colData(result)$sample, c("A", "C"))
   expect_identical(
     SummarizedExperiment::rowData(result)$variable,
-    c("V1", "V3")
+    c("X", "Z")
   )
   expect_identical(
     SummarizedExperiment::assay(result, "scaled"),

--- a/tests/testthat/test-dplyr-filter.R
+++ b/tests/testthat/test-dplyr-filter.R
@@ -62,6 +62,29 @@ test_that("filtering SummarizedExperiment uses virtual identifiers", {
   )
 })
 
+test_that("filtering SummarizedExperiment preserves duplicated-name positions", {
+  abundance <- matrix(
+    1:4,
+    nrow = 2,
+    dimnames = list(c("V1", "V1"), c("S1", "S1"))
+  )
+  se <- SummarizedExperiment::SummarizedExperiment(
+    assays = list(abundance = abundance),
+    colData = S4Vectors::DataFrame(batch = c("A", "B")),
+    rowData = S4Vectors::DataFrame(type = c("X", "Y"))
+  )
+
+  result <- se |>
+    filter_obs(batch == "B") |>
+    filter_var(type == "Y")
+
+  expect_identical(SummarizedExperiment::assay(result)[[1]], 4L)
+  expect_identical(SummarizedExperiment::colData(result)$batch, "B")
+  expect_identical(SummarizedExperiment::rowData(result)$type, "Y")
+  expect_identical(colnames(result), "S1")
+  expect_identical(rownames(result), "V1")
+})
+
 
 test_that("filtering to no samples/variables results in an empty experiment", {
   exp <- create_test_exp(c("S1", "S2", "S3"), c("V1", "V2", "V3"))

--- a/tests/testthat/test-dplyr-join.R
+++ b/tests/testthat/test-dplyr-join.R
@@ -23,18 +23,18 @@ test_that("left_join_obs works correctly", {
 
 test_that("all join verbs support SummarizedExperiment", {
   se <- create_test_se(c("S1", "S2", "S3"), c("V1", "V2", "V3"))
-  obs_info <- tibble::tibble(sample = c("S1", "S3"), batch = c(1, 2))
-  var_info <- tibble::tibble(variable = c("V1", "V3"), score = c(1, 2))
+  obs_info <- tibble::tibble(.sample = c("S1", "S3"), batch = c(1, 2))
+  var_info <- tibble::tibble(.variable = c("V1", "V3"), score = c(1, 2))
 
   results <- list(
-    left_join_obs(se, obs_info, by = "sample"),
-    inner_join_obs(se, obs_info, by = "sample"),
-    semi_join_obs(se, obs_info, by = "sample"),
-    anti_join_obs(se, obs_info, by = "sample"),
-    left_join_var(se, var_info, by = "variable"),
-    inner_join_var(se, var_info, by = "variable"),
-    semi_join_var(se, var_info, by = "variable"),
-    anti_join_var(se, var_info, by = "variable")
+    left_join_obs(se, obs_info, by = ".sample"),
+    inner_join_obs(se, obs_info, by = ".sample"),
+    semi_join_obs(se, obs_info, by = ".sample"),
+    anti_join_obs(se, obs_info, by = ".sample"),
+    left_join_var(se, var_info, by = ".variable"),
+    inner_join_var(se, var_info, by = ".variable"),
+    semi_join_var(se, var_info, by = ".variable"),
+    anti_join_var(se, var_info, by = ".variable")
   )
 
   purrr::walk(results, ~ expect_s4_class(.x, "SummarizedExperiment"))

--- a/tests/testthat/test-dplyr-join.R
+++ b/tests/testthat/test-dplyr-join.R
@@ -21,6 +21,39 @@ test_that("left_join_obs works correctly", {
   expect_equal(result$expr_mat, exp$expr_mat)
 })
 
+test_that("all join verbs support SummarizedExperiment", {
+  se <- create_test_se(c("S1", "S2", "S3"), c("V1", "V2", "V3"))
+  obs_info <- tibble::tibble(sample = c("S1", "S3"), batch = c(1, 2))
+  var_info <- tibble::tibble(variable = c("V1", "V3"), score = c(1, 2))
+
+  results <- list(
+    left_join_obs(se, obs_info, by = "sample"),
+    inner_join_obs(se, obs_info, by = "sample"),
+    semi_join_obs(se, obs_info, by = "sample"),
+    anti_join_obs(se, obs_info, by = "sample"),
+    left_join_var(se, var_info, by = "variable"),
+    inner_join_var(se, var_info, by = "variable"),
+    semi_join_var(se, var_info, by = "variable"),
+    anti_join_var(se, var_info, by = "variable")
+  )
+
+  purrr::walk(results, ~ expect_s4_class(.x, "SummarizedExperiment"))
+  expect_identical(
+    SummarizedExperiment::colData(results[[1]])$batch,
+    c(1, NA, 2)
+  )
+  expect_identical(colnames(results[[2]]), c("S1", "S3"))
+  expect_identical(colnames(results[[3]]), c("S1", "S3"))
+  expect_identical(colnames(results[[4]]), "S2")
+  expect_identical(
+    SummarizedExperiment::rowData(results[[5]])$score,
+    c(1, NA, 2)
+  )
+  expect_identical(rownames(results[[6]]), c("V1", "V3"))
+  expect_identical(rownames(results[[7]]), c("V1", "V3"))
+  expect_identical(rownames(results[[8]]), "V2")
+})
+
 
 test_that("left_join_obs handles missing values correctly", {
   exp <- create_test_exp(c("S1", "S2", "S3"), c("V1", "V2", "V3"))

--- a/tests/testthat/test-dplyr-mutate.R
+++ b/tests/testthat/test-dplyr-mutate.R
@@ -6,6 +6,20 @@ test_that("mutating sample info works", {
   expect_equal(new_exp$sample_info$new_col, 1:3)
 })
 
+test_that("mutate verbs support SummarizedExperiment", {
+  se <- create_test_se(c("S1", "S2", "S3"), c("V1", "V2", "V3"))
+
+  result <- se |>
+    mutate_obs(sample = paste0(sample, "_new"), batch = 1:3) |>
+    mutate_var(variable = paste0(variable, "_new"), score = 3:1)
+
+  expect_identical(colnames(result), paste0(c("S1", "S2", "S3"), "_new"))
+  expect_identical(rownames(result), paste0(c("V1", "V2", "V3"), "_new"))
+  expect_identical(SummarizedExperiment::colData(result)$batch, 1:3)
+  expect_identical(SummarizedExperiment::rowData(result)$score, 3:1)
+  expect_identical(S4Vectors::metadata(result)$marker, "preserved")
+})
+
 
 test_that("mutating variable info works", {
   exp <- create_test_exp(c("S1", "S2", "S3"), c("V1", "V2", "V3"))

--- a/tests/testthat/test-dplyr-mutate.R
+++ b/tests/testthat/test-dplyr-mutate.R
@@ -8,16 +8,44 @@ test_that("mutating sample info works", {
 
 test_that("mutate verbs support SummarizedExperiment", {
   se <- create_test_se(c("S1", "S2", "S3"), c("V1", "V2", "V3"))
+  SummarizedExperiment::colData(se)$sample <- c("A", "B", "C")
+  SummarizedExperiment::rowData(se)$variable <- c("X", "Y", "Z")
 
   result <- se |>
-    mutate_obs(sample = paste0(sample, "_new"), batch = 1:3) |>
-    mutate_var(variable = paste0(variable, "_new"), score = 3:1)
+    mutate_obs(
+      .sample = paste0(.sample, "_new"),
+      sample = paste0(sample, "_metadata"),
+      batch = 1:3
+    ) |>
+    mutate_var(
+      .variable = paste0(.variable, "_new"),
+      variable = paste0(variable, "_metadata"),
+      score = 3:1
+    )
 
   expect_identical(colnames(result), paste0(c("S1", "S2", "S3"), "_new"))
   expect_identical(rownames(result), paste0(c("V1", "V2", "V3"), "_new"))
   expect_identical(SummarizedExperiment::colData(result)$batch, 1:3)
   expect_identical(SummarizedExperiment::rowData(result)$score, 3:1)
+  expect_identical(
+    SummarizedExperiment::colData(result)$sample,
+    paste0(c("A", "B", "C"), "_metadata")
+  )
+  expect_identical(
+    SummarizedExperiment::rowData(result)$variable,
+    paste0(c("X", "Y", "Z"), "_metadata")
+  )
   expect_identical(S4Vectors::metadata(result)$marker, "preserved")
+})
+
+test_that("SummarizedExperiment virtual identifier names are reserved", {
+  obs_se <- create_test_se(c("S1", "S2", "S3"), c("V1", "V2", "V3"))
+  SummarizedExperiment::colData(obs_se)$.sample <- c("A", "B", "C")
+  expect_error(mutate_obs(obs_se, value = 1), "reserved for dimension names")
+
+  var_se <- create_test_se(c("S1", "S2", "S3"), c("V1", "V2", "V3"))
+  SummarizedExperiment::rowData(var_se)$.variable <- c("X", "Y", "Z")
+  expect_error(mutate_var(var_se, value = 1), "reserved for dimension names")
 })
 
 

--- a/tests/testthat/test-dplyr-rename.R
+++ b/tests/testthat/test-dplyr-rename.R
@@ -33,6 +33,14 @@ test_that("rename verbs support SummarizedExperiment", {
     rename_var(se, id = .variable),
     "could not rename the.*\\.variable"
   )
+  expect_error(
+    rename_obs(se, .sample = sample),
+    "reserved for dimension names"
+  )
+  expect_error(
+    rename_var(se, .variable = variable),
+    "reserved for dimension names"
+  )
 })
 
 

--- a/tests/testthat/test-dplyr-rename.R
+++ b/tests/testthat/test-dplyr-rename.R
@@ -8,6 +8,19 @@ test_that("renaming info tibbles works", {
   expect_identical(colnames(exp2$var_info), c("variable", "new_type"))
 })
 
+test_that("rename verbs support SummarizedExperiment", {
+  se <- create_test_se(c("S1", "S2", "S3"), c("V1", "V2", "V3"))
+
+  result <- se |>
+    rename_obs(condition = group) |>
+    rename_var(class = type)
+
+  expect_identical(colnames(SummarizedExperiment::colData(result)), "condition")
+  expect_identical(colnames(SummarizedExperiment::rowData(result)), "class")
+  expect_identical(colnames(result), c("S1", "S2", "S3"))
+  expect_identical(rownames(result), c("V1", "V2", "V3"))
+})
+
 
 test_that("trying to rename non-existing columns throws an error", {
   exp <- create_test_exp(c("S1", "S2", "S3"), c("V1", "V2", "V3"))

--- a/tests/testthat/test-dplyr-rename.R
+++ b/tests/testthat/test-dplyr-rename.R
@@ -10,15 +10,29 @@ test_that("renaming info tibbles works", {
 
 test_that("rename verbs support SummarizedExperiment", {
   se <- create_test_se(c("S1", "S2", "S3"), c("V1", "V2", "V3"))
+  SummarizedExperiment::colData(se)$sample <- c("A", "B", "C")
+  SummarizedExperiment::rowData(se)$variable <- c("X", "Y", "Z")
 
   result <- se |>
-    rename_obs(condition = group) |>
-    rename_var(class = type)
+    rename_obs(condition = group, sample_id = sample) |>
+    rename_var(class = type, variable_id = variable)
 
-  expect_identical(colnames(SummarizedExperiment::colData(result)), "condition")
-  expect_identical(colnames(SummarizedExperiment::rowData(result)), "class")
+  expect_identical(
+    colnames(SummarizedExperiment::colData(result)),
+    c("condition", "sample_id")
+  )
+  expect_identical(
+    colnames(SummarizedExperiment::rowData(result)),
+    c("class", "variable_id")
+  )
   expect_identical(colnames(result), c("S1", "S2", "S3"))
   expect_identical(rownames(result), c("V1", "V2", "V3"))
+
+  expect_error(rename_obs(se, id = .sample), "could not rename the.*\\.sample")
+  expect_error(
+    rename_var(se, id = .variable),
+    "could not rename the.*\\.variable"
+  )
 })
 
 

--- a/tests/testthat/test-dplyr-select.R
+++ b/tests/testthat/test-dplyr-select.R
@@ -37,6 +37,14 @@ test_that("select verbs support SummarizedExperiment", {
 
   expect_error(select_obs(se, .sample), "should not explicitly select")
   expect_error(select_var(se, .variable), "should not explicitly select")
+  expect_error(
+    select_obs(se, .sample = sample),
+    "reserved for dimension names"
+  )
+  expect_error(
+    select_var(se, .variable = variable),
+    "reserved for dimension names"
+  )
 })
 
 

--- a/tests/testthat/test-dplyr-select.R
+++ b/tests/testthat/test-dplyr-select.R
@@ -15,6 +15,19 @@ test_that("selecting variable info works", {
   expect_identical(colnames(exp2$var_info), c("variable", "col1"))
 })
 
+test_that("select verbs support SummarizedExperiment", {
+  se <- create_test_se(c("S1", "S2", "S3"), c("V1", "V2", "V3"))
+
+  result <- se |>
+    select_obs(group) |>
+    select_var(type)
+
+  expect_identical(colnames(SummarizedExperiment::colData(result)), "group")
+  expect_identical(colnames(SummarizedExperiment::rowData(result)), "type")
+  expect_identical(colnames(result), c("S1", "S2", "S3"))
+  expect_identical(rownames(result), c("V1", "V2", "V3"))
+})
+
 
 test_that("selecting 'sample' column raises an error", {
   exp <- create_test_exp_2()

--- a/tests/testthat/test-dplyr-select.R
+++ b/tests/testthat/test-dplyr-select.R
@@ -17,15 +17,26 @@ test_that("selecting variable info works", {
 
 test_that("select verbs support SummarizedExperiment", {
   se <- create_test_se(c("S1", "S2", "S3"), c("V1", "V2", "V3"))
+  SummarizedExperiment::colData(se)$sample <- c("A", "B", "C")
+  SummarizedExperiment::rowData(se)$variable <- c("X", "Y", "Z")
 
   result <- se |>
-    select_obs(group) |>
-    select_var(type)
+    select_obs(group, sample) |>
+    select_var(type, variable)
 
-  expect_identical(colnames(SummarizedExperiment::colData(result)), "group")
-  expect_identical(colnames(SummarizedExperiment::rowData(result)), "type")
+  expect_identical(
+    colnames(SummarizedExperiment::colData(result)),
+    c("group", "sample")
+  )
+  expect_identical(
+    colnames(SummarizedExperiment::rowData(result)),
+    c("type", "variable")
+  )
   expect_identical(colnames(result), c("S1", "S2", "S3"))
   expect_identical(rownames(result), c("V1", "V2", "V3"))
+
+  expect_error(select_obs(se, .sample), "should not explicitly select")
+  expect_error(select_var(se, .variable), "should not explicitly select")
 })
 
 

--- a/tests/testthat/test-dplyr-slice.R
+++ b/tests/testthat/test-dplyr-slice.R
@@ -19,6 +19,37 @@ test_that("slice_var works", {
   expect_equal(nrow(sliced_exp$var_info), 2)
 })
 
+test_that("every slice verb supports SummarizedExperiment", {
+  se <- create_test_se(
+    c("S1", "S2", "S3", "S4", "S5"),
+    c("V1", "V2", "V3", "V4", "V5")
+  ) |>
+    mutate_obs(score = 1:5, weight = rep(1, 5)) |>
+    mutate_var(score = 1:5, weight = rep(1, 5))
+
+  obs_results <- list(
+    slice_obs(se, 1, 3),
+    slice_head_obs(se, n = 2),
+    slice_tail_obs(se, n = 2),
+    slice_sample_obs(se, n = 2, weight_by = weight),
+    slice_max_obs(se, order_by = score, n = 2),
+    slice_min_obs(se, order_by = score, n = 2)
+  )
+  var_results <- list(
+    slice_var(se, 1, 3),
+    slice_head_var(se, n = 2),
+    slice_tail_var(se, n = 2),
+    slice_sample_var(se, n = 2, weight_by = weight),
+    slice_max_var(se, order_by = score, n = 2),
+    slice_min_var(se, order_by = score, n = 2)
+  )
+
+  purrr::walk(obs_results, ~ expect_s4_class(.x, "SummarizedExperiment"))
+  purrr::walk(obs_results, ~ expect_equal(ncol(.x), 2))
+  purrr::walk(var_results, ~ expect_s4_class(.x, "SummarizedExperiment"))
+  purrr::walk(var_results, ~ expect_equal(nrow(.x), 2))
+})
+
 
 test_that("slice_head_obs works", {
   exp <- create_test_exp(c("S1", "S2", "S3", "S4", "S5"), c("V1", "V2"))


### PR DESCRIPTION
## Summary

Add native `SummarizedExperiment` support to all tidy manipulation verbs while preserving the existing `experiment()` behavior.

## Background

This is an additive migration step for glyexp #15. It retains the domain-specific tidy helpers while extending them to Bioconductor-native containers.

## Details

- support `SummarizedExperiment` across `filter_*()`, `mutate_*()`, `select_*()`, `arrange_*()`, every `slice_*()`, and all observation/variable join helpers
- expose SE dimension identifiers as reserved virtual `.sample` and `.variable` columns
- keep physical `sample` and `variable` fields in `colData()` and `rowData()` as ordinary metadata
- preserve exact assay/metadata alignment by carrying dimension positions even when SE dimnames are duplicated
- reject select/rename aliases that create reserved virtual identifier columns
- preserve assays, metadata, dimension ordering, and SE subclasses
- document identifier-column behavior once on the mutate topic and inherit it across the other tidy-verb topics
- retain existing `experiment()` behavior unchanged

## Verification

- `devtools::document()`
- focused tests for all seven tidy-verb test files: 251 assertions passed
- `devtools::test()`: 713 assertions passed
- `devtools::check(error_on = "warning")`: completed successfully
- `air format` on modified R and test files
- `git diff --check`
