### PR TITLE
fix: preserve factor levels when filtering

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # glyexp (development version)
 
+* `filter_col()` and `filter_row()` now preserve unused factor levels by default; set `.drop_levels = TRUE` to drop them. (#30)
 * Dplyr-style manipulation helpers now use `_col()` and `_row()` suffixes; the former `_obs()` and `_var()` names remain available with a soft-deprecation warning. (#29)
 * Bundled `real_experiment` and `real_experiment2` now use `GlycoproteomicSE` and `GlycomicSE`; `toy_experiment` has been removed. (#28)
 * All tidy manipulation verbs (`filter_*()`, `mutate_*()`, `select_*()`, `arrange_*()`, `rename_*()`, `slice_*()`, and `*_join_*()`) now accept `SummarizedExperiment` objects, exposing dimension identifiers as virtual `.sample` and `.variable` columns while retaining existing `experiment()` behavior. (#25)

--- a/R/dplyr-filter.R
+++ b/R/dplyr-filter.R
@@ -13,8 +13,8 @@
 #'
 #' @details
 #' One difference between `filter_col()` or `filter_row()` and [dplyr::filter] is that,
-#' when filtering on factor columns, the unused levels are automatically dropped by default.
-#' This behavior can be turnt off by setting `.drop_levels` to FALSE.
+#' when filtering on factor columns, unused levels can be dropped by setting
+#' `.drop_levels` to `TRUE`.
 #'
 #' @param exp An [experiment()] or `SummarizedExperiment` object.
 #' @param ... <[`data-masking`][rlang::args_data_masking]> Expression to filter samples or variables.
@@ -47,7 +47,7 @@
 #' sub_exp_3
 #'
 #' @export
-filter_col <- function(exp, ..., .drop_levels = TRUE) {
+filter_col <- function(exp, ..., .drop_levels = FALSE) {
   filter_info_data(
     exp = exp,
     info_field = "sample_info",
@@ -61,7 +61,7 @@ filter_col <- function(exp, ..., .drop_levels = TRUE) {
 
 #' @rdname filter_col
 #' @export
-filter_row <- function(exp, ..., .drop_levels = TRUE) {
+filter_row <- function(exp, ..., .drop_levels = FALSE) {
   filter_info_data(
     exp = exp,
     info_field = "var_info",

--- a/man/filter_col.Rd
+++ b/man/filter_col.Rd
@@ -5,9 +5,9 @@
 \alias{filter_row}
 \title{Filter samples or variables of an experiment}
 \usage{
-filter_col(exp, ..., .drop_levels = TRUE)
+filter_col(exp, ..., .drop_levels = FALSE)
 
-filter_row(exp, ..., .drop_levels = TRUE)
+filter_row(exp, ..., .drop_levels = FALSE)
 }
 \arguments{
 \item{exp}{An \code{\link[=experiment]{experiment()}} or \code{SummarizedExperiment} object.}
@@ -34,8 +34,8 @@ and then updates the expression matrix accordingly.
 }
 \details{
 One difference between \code{filter_col()} or \code{filter_row()} and \link[dplyr:filter]{dplyr::filter} is that,
-when filtering on factor columns, the unused levels are automatically dropped by default.
-This behavior can be turnt off by setting \code{.drop_levels} to FALSE.
+when filtering on factor columns, unused levels can be dropped by setting
+\code{.drop_levels} to \code{TRUE}.
 }
 \section{Identifier columns}{
 

--- a/tests/testthat/test-dplyr-filter.R
+++ b/tests/testthat/test-dplyr-filter.R
@@ -136,7 +136,7 @@ test_that("other items in list are preserved", {
 })
 
 
-test_that("drop levels by default", {
+test_that("preserve levels by default", {
   exp <- create_test_exp(c("S1", "S2", "S3"), c("V1", "V2", "V3"))
   exp$sample_info <- tibble::tibble(
     sample = c("S1", "S2", "S3"),
@@ -146,12 +146,12 @@ test_that("drop levels by default", {
 
   exp2 <- filter_col(exp, group %in% c("A", "B"))
 
-  expect_equal(levels(exp2$sample_info$group), c("A", "B"))
+  expect_equal(levels(exp2$sample_info$group), c("A", "B", "C"))
   expect_equal(levels(exp2$sample_info$batch), c("X", "Y", "Z"))
 })
 
 
-test_that("setting .drop_levels to FALSE disables dropping levels", {
+test_that("setting .drop_levels to TRUE drops levels", {
   exp <- create_test_exp(c("S1", "S2", "S3"), c("V1", "V2", "V3"))
   exp$sample_info <- tibble::tibble(
     sample = c("S1", "S2", "S3"),
@@ -159,9 +159,9 @@ test_that("setting .drop_levels to FALSE disables dropping levels", {
     batch = factor(c("X", "Y", "Z"), levels = c("X", "Y", "Z"))
   )
 
-  exp2 <- filter_col(exp, group %in% c("A", "B"), .drop_levels = FALSE)
+  exp2 <- filter_col(exp, group %in% c("A", "B"), .drop_levels = TRUE)
 
-  expect_equal(levels(exp2$sample_info$group), c("A", "B", "C"))
+  expect_equal(levels(exp2$sample_info$group), c("A", "B"))
   expect_equal(levels(exp2$sample_info$batch), c("X", "Y", "Z"))
 })
 


### PR DESCRIPTION
## Summary

Make `.drop_levels` default to `FALSE` for `filter_col()` and `filter_row()`.

## Details

- Preserve unused factor levels unless callers explicitly set `.drop_levels = TRUE`.
- Update the filter documentation and regression tests for the new default.

## Verification

- `Rscript -e 'devtools::test(filter = "dplyr-filter")'`
- `Rscript -e 'devtools::test()'`
- `Rscript -e 'devtools::check()'`

Closes #27