### PR TITLE
fix: error on missing tidy identifiers

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,8 +1,6 @@
 # glyexp (development version)
 
-* Tidy manipulation verbs now error when `.sample` or `.variable` is used
-  without corresponding dimension names. `mutate_col(.sample = ...)` and
-  `mutate_row(.variable = ...)` can still create missing names. (#31)
+* Tidy manipulation verbs now error when `.sample` or `.variable` is used without corresponding dimension names; `mutate_col(.sample = ...)` and `mutate_row(.variable = ...)` can still create missing names. (#31)
 
 # glyexp 0.16.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # glyexp (development version)
 
+* Tidy manipulation verbs now error when `.sample` or `.variable` is used
+  without corresponding dimension names. `mutate_col(.sample = ...)` and
+  `mutate_row(.variable = ...)` can still create missing names.
+
 # glyexp 0.16.0
 
 ## Breaking changes

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 * Tidy manipulation verbs now error when `.sample` or `.variable` is used
   without corresponding dimension names. `mutate_col(.sample = ...)` and
-  `mutate_row(.variable = ...)` can still create missing names.
+  `mutate_row(.variable = ...)` can still create missing names. (#31)
 
 # glyexp 0.16.0
 

--- a/R/dplyr-arrange.R
+++ b/R/dplyr-arrange.R
@@ -68,7 +68,7 @@ arrange_info_data <- function(exp, info_field, id_column, matrix_updater, ...) {
 
   # Get original data and arrange it
   original_data <- tidy_info_data(exp, info_field, id_column)
-  new_data <- try_arrange(original_data, info_field, ...)
+  new_data <- try_arrange(original_data, info_field, id_column, ...)
 
   if (methods::is(exp, "SummarizedExperiment")) {
     return(update_se_info(exp, new_data, info_field, id_column, subset = TRUE))
@@ -87,13 +87,18 @@ arrange_info_data <- function(exp, info_field, id_column, matrix_updater, ...) {
 }
 
 # Wrapper for dplyr::arrange() that provides better error messages
-try_arrange <- function(data, data_type, ...) {
+try_arrange <- function(data, data_type, id_column, ...) {
   tryCatch(
     dplyr::arrange(data, ...),
     error = function(e) {
       missing_col <- extract_missing_column(conditionMessage(e))
       if (!is.na(missing_col)) {
-        abort_missing_column(missing_col, data_type, colnames(data))
+        abort_missing_tidy_column(
+          missing_col,
+          data_type,
+          colnames(data),
+          id_column
+        )
       }
       cli::cli_abort(conditionMessage(e), call = NULL)
     }

--- a/R/dplyr-arrange.R
+++ b/R/dplyr-arrange.R
@@ -40,35 +40,43 @@
 #'
 #' @export
 arrange_col <- function(exp, ...) {
+  quos <- rlang::enquos(...)
   arrange_info_data(
     exp = exp,
+    quos = quos,
     info_field = "sample_info",
     id_column = "sample",
-    matrix_updater = function(mat, ids) mat[, ids, drop = FALSE],
-    ...
+    matrix_updater = function(mat, ids) mat[, ids, drop = FALSE]
   )
 }
 
 #' @rdname arrange_col
 #' @export
 arrange_row <- function(exp, ...) {
+  quos <- rlang::enquos(...)
   arrange_info_data(
     exp = exp,
+    quos = quos,
     info_field = "var_info",
     id_column = "variable",
-    matrix_updater = function(mat, ids) mat[ids, , drop = FALSE],
-    ...
+    matrix_updater = function(mat, ids) mat[ids, , drop = FALSE]
   )
 }
 
 # Internal function that handles the common logic for both arrange_col and arrange_row
-arrange_info_data <- function(exp, info_field, id_column, matrix_updater, ...) {
+arrange_info_data <- function(
+  exp,
+  quos,
+  info_field,
+  id_column,
+  matrix_updater
+) {
   stopifnot(is_tidy_container(exp))
   id_column <- tidy_id_column(exp, id_column)
 
   # Get original data and arrange it
   original_data <- tidy_info_data(exp, info_field, id_column)
-  new_data <- try_arrange(original_data, info_field, id_column, ...)
+  new_data <- try_arrange(original_data, info_field, id_column, quos)
 
   if (methods::is(exp, "SummarizedExperiment")) {
     return(update_se_info(exp, new_data, info_field, id_column, subset = TRUE))
@@ -87,9 +95,9 @@ arrange_info_data <- function(exp, info_field, id_column, matrix_updater, ...) {
 }
 
 # Wrapper for dplyr::arrange() that provides better error messages
-try_arrange <- function(data, data_type, id_column, ...) {
+try_arrange <- function(data, data_type, id_column, quos) {
   tryCatch(
-    dplyr::arrange(data, ...),
+    dplyr::arrange(data, !!!quos),
     error = function(e) {
       missing_col <- extract_missing_column(conditionMessage(e))
       if (!is.na(missing_col)) {

--- a/R/dplyr-filter.R
+++ b/R/dplyr-filter.R
@@ -89,7 +89,7 @@ filter_info_data <- function(
   # Get original data and filter it
   original_data <- tidy_info_data(exp, info_field, id_column)
   quos <- rlang::enquos(...)
-  new_data <- try_filter(original_data, info_field, dim_name, quos)
+  new_data <- try_filter(original_data, info_field, id_column, dim_name, quos)
   if (isTRUE(.drop_levels)) {
     new_data <- drop_filter_levels(new_data, original_data, quos)
   }
@@ -110,7 +110,7 @@ filter_info_data <- function(
   new_exp
 }
 
-try_filter <- function(data, data_type, dim_name, quos) {
+try_filter <- function(data, data_type, id_column, dim_name, quos) {
   # data: `sample_info` or `var_info`
   # data_type: "sample_info" or "var_info", used in error messages
   # dim_name: "samples" or "variables", used in error messages
@@ -120,7 +120,12 @@ try_filter <- function(data, data_type, dim_name, quos) {
     error = function(e) {
       missing_col <- extract_missing_column(conditionMessage(e))
       if (!is.na(missing_col)) {
-        abort_missing_column(missing_col, data_type, colnames(data))
+        abort_missing_tidy_column(
+          missing_col,
+          data_type,
+          colnames(data),
+          id_column
+        )
       }
       cli::cli_abort(conditionMessage(e), call = NULL)
     }

--- a/R/dplyr-join.R
+++ b/R/dplyr-join.R
@@ -196,6 +196,7 @@ join_info_data <- function(
       by = by,
       join_type = join_type,
       info_field = info_field,
+      id_column = id_column,
       dim_name = dim_name,
       relationship = "many-to-one",
       ...
@@ -208,12 +209,24 @@ join_info_data <- function(
       by = by,
       join_type = join_type,
       info_field = info_field,
+      id_column = id_column,
       dim_name = dim_name,
       ...
     )
   }
 
   if (methods::is(exp, "SummarizedExperiment")) {
+    if (
+      !id_column %in% colnames(original_data) &&
+        id_column %in% colnames(new_data)
+    ) {
+      data_name <- if (info_field == "sample_info") {
+        "colData(exp)"
+      } else {
+        "rowData(exp)"
+      }
+      abort_reserved_tidy_column(id_column, data_name)
+    }
     return(update_se_info(exp, new_data, info_field, id_column, subset = TRUE))
   }
 
@@ -230,7 +243,16 @@ join_info_data <- function(
 }
 
 # Wrapper for dplyr join functions that provides better error messages
-try_join <- function(x, y, by, join_type, info_field, dim_name, ...) {
+try_join <- function(
+  x,
+  y,
+  by,
+  join_type,
+  info_field,
+  id_column,
+  dim_name,
+  ...
+) {
   # Select the appropriate dplyr join function
   join_func <- switch(
     join_type,
@@ -245,6 +267,13 @@ try_join <- function(x, y, by, join_type, info_field, dim_name, ...) {
     join_func(x, y, by = by, ...),
     error = function(e) {
       error_msg <- conditionMessage(e)
+
+      if (
+        !id_column %in% colnames(x) &&
+          grepl(paste0("`", id_column, "`"), error_msg, fixed = TRUE)
+      ) {
+        abort_missing_tidy_identifier(id_column)
+      }
 
       # Handle common join errors with better messages
       if (grepl("Join columns must be present", error_msg)) {

--- a/R/dplyr-mutate.R
+++ b/R/dplyr-mutate.R
@@ -73,16 +73,17 @@
 #'
 #' @export
 mutate_col <- function(exp, ...) {
+  quos <- rlang::enquos(...)
   mutate_info_data(
     exp = exp,
+    quos = quos,
     info_type = "sample",
     info_field = "sample_info",
     id_column = "sample",
     matrix_dimnames_setter = function(mat, new_names) {
       colnames(mat) <- new_names
       mat
-    },
-    ...
+    }
   )
 }
 
@@ -90,16 +91,17 @@ mutate_col <- function(exp, ...) {
 #' @rdname mutate_col
 #' @export
 mutate_row <- function(exp, ...) {
+  quos <- rlang::enquos(...)
   mutate_info_data(
     exp = exp,
+    quos = quos,
     info_type = "variable",
     info_field = "var_info",
     id_column = "variable",
     matrix_dimnames_setter = function(mat, new_names) {
       rownames(mat) <- new_names
       mat
-    },
-    ...
+    }
   )
 }
 
@@ -107,18 +109,18 @@ mutate_row <- function(exp, ...) {
 # Internal function that handles the common logic for both mutate_col and mutate_row
 mutate_info_data <- function(
   exp,
+  quos,
   info_type,
   info_field,
   id_column,
-  matrix_dimnames_setter,
-  ...
+  matrix_dimnames_setter
 ) {
   stopifnot(is_tidy_container(exp))
   id_column <- tidy_id_column(exp, id_column)
 
   # Get original data and mutate it
   original_data <- tidy_info_data(exp, info_field, id_column)
-  new_data <- try_mutate(original_data, info_field, id_column, ...)
+  new_data <- try_mutate(original_data, info_field, id_column, quos)
 
   # Check if the ID column was modified
   original_ids <- original_data[[id_column]]
@@ -155,9 +157,9 @@ mutate_info_data <- function(
 }
 
 # Wrapper for dplyr::mutate() that provides better error messages
-try_mutate <- function(data, data_type, id_column, ...) {
+try_mutate <- function(data, data_type, id_column, quos) {
   tryCatch(
-    dplyr::mutate(data, ...),
+    dplyr::mutate(data, !!!quos),
     error = function(e) {
       missing_col <- extract_missing_column(conditionMessage(e))
       if (!is.na(missing_col)) {

--- a/R/dplyr-mutate.R
+++ b/R/dplyr-mutate.R
@@ -38,6 +38,10 @@
 #' reserved; an input containing either name in the corresponding metadata
 #' raises an error rather than overwriting that column.
 #'
+#' If the corresponding dimension names are `NULL`, the virtual identifier is
+#' unavailable and referring to it raises an error. `mutate_col(.sample = ...)`
+#' or `mutate_row(.variable = ...)` can be used to create the missing names.
+#'
 #' @examples
 #' library(SummarizedExperiment)
 #'
@@ -114,7 +118,7 @@ mutate_info_data <- function(
 
   # Get original data and mutate it
   original_data <- tidy_info_data(exp, info_field, id_column)
-  new_data <- try_mutate(original_data, info_field, ...)
+  new_data <- try_mutate(original_data, info_field, id_column, ...)
 
   # Check if the ID column was modified
   original_ids <- original_data[[id_column]]
@@ -151,13 +155,18 @@ mutate_info_data <- function(
 }
 
 # Wrapper for dplyr::mutate() that provides better error messages
-try_mutate <- function(data, data_type, ...) {
+try_mutate <- function(data, data_type, id_column, ...) {
   tryCatch(
     dplyr::mutate(data, ...),
     error = function(e) {
       missing_col <- extract_missing_column(conditionMessage(e))
       if (!is.na(missing_col)) {
-        abort_missing_column(missing_col, data_type, colnames(data))
+        abort_missing_tidy_column(
+          missing_col,
+          data_type,
+          colnames(data),
+          id_column
+        )
       }
       stop(e)
     }

--- a/R/dplyr-rename.R
+++ b/R/dplyr-rename.R
@@ -71,10 +71,8 @@ rename_info_data <- function(exp, info_field, id_column, ...) {
 }
 
 rename_data <- function(data, data_name, info_type, ...) {
-  protected_columns <- intersect(
-    c(info_type, tidy_position_column()),
-    colnames(data)
-  )
+  reserved_columns <- c(info_type, tidy_position_column())
+  protected_columns <- intersect(reserved_columns, colnames(data))
 
   # Create a prototype (empty data frame with same structure) for validation
   prototype <- data[0, ]
@@ -86,19 +84,25 @@ rename_data <- function(data, data_name, info_type, ...) {
   )
 
   # Try renaming on the prototype first to validate
-  validate_rename(prototype_without_id, data_name, info_type, ...)
+  validate_rename(
+    prototype_without_id,
+    data_name,
+    info_type,
+    id_exists = info_type %in% protected_columns,
+    ...
+  )
 
   # If validation passes, perform the actual renaming
   protected_data <- dplyr::select(data, dplyr::all_of(protected_columns))
   new_data <- dplyr::select(data, -dplyr::all_of(protected_columns))
   new_data <- dplyr::rename(new_data, ...)
-  check_reserved_tidy_columns(new_data, protected_columns, data_name)
+  check_reserved_tidy_columns(new_data, reserved_columns, data_name)
   new_data <- dplyr::bind_cols(protected_data, new_data)
 
   new_data
 }
 
-validate_rename <- function(prototype, data_name, info_type, ...) {
+validate_rename <- function(prototype, data_name, info_type, id_exists, ...) {
   tryCatch(
     {
       # Try the renaming on the prototype
@@ -109,6 +113,9 @@ validate_rename <- function(prototype, data_name, info_type, ...) {
       missing_col <- extract_missing_column(conditionMessage(e))
       if (!is.na(missing_col)) {
         if (missing_col == info_type) {
+          if (!id_exists && info_type %in% c(".sample", ".variable")) {
+            abort_missing_tidy_identifier(info_type)
+          }
           cli::cli_abort(
             "You could not rename the {.val {info_type}} column in `{data_name}`.",
             call = NULL

--- a/R/dplyr-select.R
+++ b/R/dplyr-select.R
@@ -74,10 +74,8 @@ select_info_data <- function(exp, info_field, id_column, ...) {
 }
 
 select_data <- function(data, data_name, info_type, ...) {
-  protected_columns <- intersect(
-    c(info_type, tidy_position_column()),
-    colnames(data)
-  )
+  reserved_columns <- c(info_type, tidy_position_column())
+  protected_columns <- intersect(reserved_columns, colnames(data))
 
   # Create a prototype (empty data frame with same structure) for validation
   prototype <- data[0, ]
@@ -89,20 +87,32 @@ select_data <- function(data, data_name, info_type, ...) {
   )
 
   # Try selection on the prototype first to validate
-  validate_selection(prototype_without_id, data_name, info_type, ...)
+  validate_selection(
+    prototype_without_id,
+    data_name,
+    info_type,
+    id_exists = info_type %in% protected_columns,
+    ...
+  )
 
   # If validation passes, perform the actual selection
   protected_data <- dplyr::select(data, dplyr::all_of(protected_columns))
   new_data <- dplyr::select(data, -dplyr::all_of(protected_columns))
   new_data <- dplyr::select(new_data, ...)
-  check_reserved_tidy_columns(new_data, protected_columns, data_name)
+  check_reserved_tidy_columns(new_data, reserved_columns, data_name)
   new_data <- dplyr::bind_cols(protected_data, new_data)
 
   new_data
 }
 
 
-validate_selection <- function(prototype, data_name, info_type, ...) {
+validate_selection <- function(
+  prototype,
+  data_name,
+  info_type,
+  id_exists,
+  ...
+) {
   tryCatch(
     {
       # Try the selection on the prototype
@@ -113,6 +123,9 @@ validate_selection <- function(prototype, data_name, info_type, ...) {
       missing_col <- extract_missing_column(conditionMessage(e))
       if (!is.na(missing_col)) {
         if (missing_col == info_type) {
+          if (!id_exists && info_type %in% c(".sample", ".variable")) {
+            abort_missing_tidy_identifier(info_type)
+          }
           cli::cli_abort(
             c(
               "You should not explicitly select or deselect the {.val {info_type}} column in `{data_name}`.",

--- a/R/dplyr-slice.R
+++ b/R/dplyr-slice.R
@@ -417,7 +417,7 @@ slice_info_data <- function(
 
   # Get original data and slice it
   original_data <- tidy_info_data(exp, info_field, id_column)
-  new_data <- try_slice(original_data, info_field, slice_fun, ...)
+  new_data <- try_slice(original_data, info_field, id_column, slice_fun, ...)
 
   if (methods::is(exp, "SummarizedExperiment")) {
     return(update_se_info(exp, new_data, info_field, id_column, subset = TRUE))
@@ -436,14 +436,19 @@ slice_info_data <- function(
 }
 
 # Wrapper for dplyr slice functions that provides better error messages
-try_slice <- function(data, data_type, slice_fun, ...) {
+try_slice <- function(data, data_type, id_column, slice_fun, ...) {
   tryCatch(
     slice_fun(data, ...),
     error = function(e) {
       error_msg <- conditionMessage(e)
       missing_col <- extract_missing_column(error_msg)
       if (!is.na(missing_col)) {
-        abort_missing_column(missing_col, data_type, colnames(data))
+        abort_missing_tidy_column(
+          missing_col,
+          data_type,
+          colnames(data),
+          id_column
+        )
       }
       cli::cli_abort(error_msg, call = NULL)
     }

--- a/R/dplyr-slice.R
+++ b/R/dplyr-slice.R
@@ -417,7 +417,13 @@ slice_info_data <- function(
 
   # Get original data and slice it
   original_data <- tidy_info_data(exp, info_field, id_column)
-  new_data <- try_slice(original_data, info_field, id_column, slice_fun, ...)
+  new_data <- try_slice(
+    original_data,
+    ...,
+    data_type = info_field,
+    id_column = id_column,
+    slice_fun = slice_fun
+  )
 
   if (methods::is(exp, "SummarizedExperiment")) {
     return(update_se_info(exp, new_data, info_field, id_column, subset = TRUE))
@@ -436,7 +442,7 @@ slice_info_data <- function(
 }
 
 # Wrapper for dplyr slice functions that provides better error messages
-try_slice <- function(data, data_type, id_column, slice_fun, ...) {
+try_slice <- function(data, ..., data_type, id_column, slice_fun) {
   tryCatch(
     slice_fun(data, ...),
     error = function(e) {

--- a/R/dplyr-utils.R
+++ b/R/dplyr-utils.R
@@ -1,7 +1,9 @@
 extract_missing_column <- function(error_msg) {
   patterns <- c(
     "object '([^']+)' not found",
-    "Column `([^`]+)` doesn't exist"
+    "Column `([^`]+)` doesn't exist",
+    "Column `([^`]+)` not found in `\\.data`",
+    "Element `([^`]+)` doesn't exist"
   )
 
   for (pattern in patterns) {
@@ -22,6 +24,59 @@ abort_missing_column <- function(missing_col, data_name, available_cols) {
     ),
     call = NULL
   )
+}
+
+#' Abort when a virtual identifier has no corresponding dimension names
+#'
+#' @param id_column Either `".sample"` or `".variable"`.
+#'
+#' @return This function does not return.
+#' @noRd
+abort_missing_tidy_identifier <- function(id_column) {
+  dimnames_accessor <- if (id_column == ".sample") {
+    "colnames(exp)"
+  } else {
+    "rownames(exp)"
+  }
+  mutate_verb <- if (id_column == ".sample") {
+    "mutate_col"
+  } else {
+    "mutate_row"
+  }
+
+  cli::cli_abort(
+    c(
+      "Cannot use {.field {id_column}} because `{dimnames_accessor}` does not exist.",
+      "i" = "Create it with `{mutate_verb}(exp, {id_column} = ...)`."
+    ),
+    call = NULL
+  )
+}
+
+#' Abort after a tidy verb refers to a missing column
+#'
+#' @param missing_col The missing column name.
+#' @param data_name The user-facing metadata name.
+#' @param available_cols Available metadata columns.
+#' @param id_column The physical or virtual identifier column.
+#'
+#' @return This function does not return.
+#' @noRd
+abort_missing_tidy_column <- function(
+  missing_col,
+  data_name,
+  available_cols,
+  id_column
+) {
+  if (
+    identical(missing_col, id_column) &&
+      !id_column %in% available_cols &&
+      id_column %in% c(".sample", ".variable")
+  ) {
+    abort_missing_tidy_identifier(id_column)
+  }
+
+  abort_missing_column(missing_col, data_name, available_cols)
 }
 
 #' Check whether an object is supported by the tidy manipulation verbs
@@ -129,16 +184,16 @@ tidy_info_data <- function(exp, info_field, id_column) {
     abort_reserved_tidy_column(reserved_column, data_name)
   }
 
-  ids <- if (info_field == "sample_info") colnames(exp) else rownames(exp)
-  if (is.null(ids)) {
-    ids <- as.character(seq_len(nrow(data)))
-  }
   data <- dplyr::mutate(
     data,
-    "{id_column}" := ids,
     "{position_column}" := seq_len(nrow(data)),
     .before = 1
   )
+
+  ids <- if (info_field == "sample_info") colnames(exp) else rownames(exp)
+  if (!is.null(ids)) {
+    data <- dplyr::mutate(data, "{id_column}" := ids, .before = 1)
+  }
 
   data
 }
@@ -160,7 +215,6 @@ update_se_info <- function(
   id_column,
   subset = FALSE
 ) {
-  new_ids <- new_data[[id_column]]
   position_column <- tidy_position_column()
 
   if (isTRUE(subset)) {
@@ -174,15 +228,20 @@ update_se_info <- function(
 
   stored_data <- dplyr::select(
     new_data,
-    -dplyr::all_of(c(id_column, position_column))
+    -dplyr::any_of(c(id_column, position_column))
   )
+  new_ids <- new_data[[id_column]]
   stored_data <- S4Vectors::DataFrame(stored_data, row.names = new_ids)
 
   if (info_field == "sample_info") {
-    colnames(exp) <- new_ids
+    if (!is.null(new_ids)) {
+      colnames(exp) <- new_ids
+    }
     SummarizedExperiment::colData(exp) <- stored_data
   } else {
-    rownames(exp) <- new_ids
+    if (!is.null(new_ids)) {
+      rownames(exp) <- new_ids
+    }
     SummarizedExperiment::rowData(exp) <- stored_data
   }
 

--- a/man/arrange_col.Rd
+++ b/man/arrange_col.Rd
@@ -47,6 +47,10 @@ Consequently, \code{sample} in \code{colData(exp)} and \code{variable} in \code{
 remain ordinary metadata columns. The names \code{.sample} and \code{.variable} are
 reserved; an input containing either name in the corresponding metadata
 raises an error rather than overwriting that column.
+
+If the corresponding dimension names are \code{NULL}, the virtual identifier is
+unavailable and referring to it raises an error. \code{mutate_col(.sample = ...)}
+or \code{mutate_row(.variable = ...)} can be used to create the missing names.
 }
 
 \examples{

--- a/man/filter_col.Rd
+++ b/man/filter_col.Rd
@@ -55,6 +55,10 @@ Consequently, \code{sample} in \code{colData(exp)} and \code{variable} in \code{
 remain ordinary metadata columns. The names \code{.sample} and \code{.variable} are
 reserved; an input containing either name in the corresponding metadata
 raises an error rather than overwriting that column.
+
+If the corresponding dimension names are \code{NULL}, the virtual identifier is
+unavailable and referring to it raises an error. \code{mutate_col(.sample = ...)}
+or \code{mutate_row(.variable = ...)} can be used to create the missing names.
 }
 
 \examples{

--- a/man/left_join_col.Rd
+++ b/man/left_join_col.Rd
@@ -80,6 +80,10 @@ Consequently, \code{sample} in \code{colData(exp)} and \code{variable} in \code{
 remain ordinary metadata columns. The names \code{.sample} and \code{.variable} are
 reserved; an input containing either name in the corresponding metadata
 raises an error rather than overwriting that column.
+
+If the corresponding dimension names are \code{NULL}, the virtual identifier is
+unavailable and referring to it raises an error. \code{mutate_col(.sample = ...)}
+or \code{mutate_row(.variable = ...)} can be used to create the missing names.
 }
 
 \seealso{

--- a/man/mutate_col.Rd
+++ b/man/mutate_col.Rd
@@ -50,6 +50,10 @@ Consequently, \code{sample} in \code{colData(exp)} and \code{variable} in \code{
 remain ordinary metadata columns. The names \code{.sample} and \code{.variable} are
 reserved; an input containing either name in the corresponding metadata
 raises an error rather than overwriting that column.
+
+If the corresponding dimension names are \code{NULL}, the virtual identifier is
+unavailable and referring to it raises an error. \code{mutate_col(.sample = ...)}
+or \code{mutate_row(.variable = ...)} can be used to create the missing names.
 }
 
 \examples{

--- a/man/rename_col.Rd
+++ b/man/rename_col.Rd
@@ -48,6 +48,10 @@ Consequently, \code{sample} in \code{colData(exp)} and \code{variable} in \code{
 remain ordinary metadata columns. The names \code{.sample} and \code{.variable} are
 reserved; an input containing either name in the corresponding metadata
 raises an error rather than overwriting that column.
+
+If the corresponding dimension names are \code{NULL}, the virtual identifier is
+unavailable and referring to it raises an error. \code{mutate_col(.sample = ...)}
+or \code{mutate_row(.variable = ...)} can be used to create the missing names.
 }
 
 \examples{

--- a/man/select_col.Rd
+++ b/man/select_col.Rd
@@ -50,6 +50,10 @@ Consequently, \code{sample} in \code{colData(exp)} and \code{variable} in \code{
 remain ordinary metadata columns. The names \code{.sample} and \code{.variable} are
 reserved; an input containing either name in the corresponding metadata
 raises an error rather than overwriting that column.
+
+If the corresponding dimension names are \code{NULL}, the virtual identifier is
+unavailable and referring to it raises an error. \code{mutate_col(.sample = ...)}
+or \code{mutate_row(.variable = ...)} can be used to create the missing names.
 }
 
 \examples{

--- a/man/slice_col.Rd
+++ b/man/slice_col.Rd
@@ -99,6 +99,10 @@ Consequently, \code{sample} in \code{colData(exp)} and \code{variable} in \code{
 remain ordinary metadata columns. The names \code{.sample} and \code{.variable} are
 reserved; an input containing either name in the corresponding metadata
 raises an error rather than overwriting that column.
+
+If the corresponding dimension names are \code{NULL}, the virtual identifier is
+unavailable and referring to it raises an error. \code{mutate_col(.sample = ...)}
+or \code{mutate_row(.variable = ...)} can be used to create the missing names.
 }
 
 \examples{

--- a/tests/testthat/_snaps/dplyr-arrange.md
+++ b/tests/testthat/_snaps/dplyr-arrange.md
@@ -16,6 +16,15 @@
       ! Cannot use .variable because `rownames(exp)` does not exist.
       i Create it with `mutate_row(exp, .variable = ...)`.
 
+---
+
+    Code
+      arrange_row(se, id = .variable)
+    Condition
+      Error:
+      ! Cannot use .variable because `rownames(exp)` does not exist.
+      i Create it with `mutate_row(exp, .variable = ...)`.
+
 # arranging with non-existing columns raises an error
 
     Code

--- a/tests/testthat/_snaps/dplyr-arrange.md
+++ b/tests/testthat/_snaps/dplyr-arrange.md
@@ -1,3 +1,21 @@
+# arrange verbs require names for virtual identifiers
+
+    Code
+      arrange_col(se, .sample)
+    Condition
+      Error:
+      ! Cannot use .sample because `colnames(exp)` does not exist.
+      i Create it with `mutate_col(exp, .sample = ...)`.
+
+---
+
+    Code
+      arrange_row(se, .variable)
+    Condition
+      Error:
+      ! Cannot use .variable because `rownames(exp)` does not exist.
+      i Create it with `mutate_row(exp, .variable = ...)`.
+
 # arranging with non-existing columns raises an error
 
     Code

--- a/tests/testthat/_snaps/dplyr-filter.md
+++ b/tests/testthat/_snaps/dplyr-filter.md
@@ -1,3 +1,21 @@
+# filter verbs require names for virtual identifiers
+
+    Code
+      filter_col(se, .sample == "S1")
+    Condition
+      Error:
+      ! Cannot use .sample because `colnames(exp)` does not exist.
+      i Create it with `mutate_col(exp, .sample = ...)`.
+
+---
+
+    Code
+      filter_row(se, .variable == "V1")
+    Condition
+      Error:
+      ! Cannot use .variable because `rownames(exp)` does not exist.
+      i Create it with `mutate_row(exp, .variable = ...)`.
+
 # filtering using non-existing columns raises an error
 
     Code

--- a/tests/testthat/_snaps/dplyr-join.md
+++ b/tests/testthat/_snaps/dplyr-join.md
@@ -1,3 +1,30 @@
+# join verbs require names for virtual identifiers
+
+    Code
+      left_join_col(se, tibble::tibble(.sample = "S1"), by = ".sample")
+    Condition
+      Error:
+      ! Cannot use .sample because `colnames(exp)` does not exist.
+      i Create it with `mutate_col(exp, .sample = ...)`.
+
+---
+
+    Code
+      left_join_row(se, tibble::tibble(.variable = "V1"), by = ".variable")
+    Condition
+      Error:
+      ! Cannot use .variable because `rownames(exp)` does not exist.
+      i Create it with `mutate_row(exp, .variable = ...)`.
+
+---
+
+    Code
+      left_join_col(se, tibble::tibble(group = "A", .sample = "S1"), by = "group")
+    Condition
+      Error:
+      ! Column .sample in `colData(exp)` is reserved for dimension names.
+      i Choose a different metadata column name.
+
 # relationship parameter is locked to many-to-one
 
     Code

--- a/tests/testthat/_snaps/dplyr-mutate.md
+++ b/tests/testthat/_snaps/dplyr-mutate.md
@@ -1,3 +1,30 @@
+# mutate verbs handle missing SummarizedExperiment names
+
+    Code
+      mutate_col(se, copied = .sample)
+    Condition
+      Error:
+      ! Cannot use .sample because `colnames(exp)` does not exist.
+      i Create it with `mutate_col(exp, .sample = ...)`.
+
+---
+
+    Code
+      mutate_row(se, copied = .variable)
+    Condition
+      Error:
+      ! Cannot use .variable because `rownames(exp)` does not exist.
+      i Create it with `mutate_row(exp, .variable = ...)`.
+
+---
+
+    Code
+      mutate_col(se, copied = .data$.sample)
+    Condition
+      Error:
+      ! Cannot use .sample because `colnames(exp)` does not exist.
+      i Create it with `mutate_col(exp, .sample = ...)`.
+
 # mutating using non-existing columns raises an error
 
     Code

--- a/tests/testthat/_snaps/dplyr-mutate.md
+++ b/tests/testthat/_snaps/dplyr-mutate.md
@@ -19,6 +19,15 @@
 ---
 
     Code
+      mutate_row(se, id = .variable)
+    Condition
+      Error:
+      ! Cannot use .variable because `rownames(exp)` does not exist.
+      i Create it with `mutate_row(exp, .variable = ...)`.
+
+---
+
+    Code
       mutate_col(se, copied = .data$.sample)
     Condition
       Error:

--- a/tests/testthat/_snaps/dplyr-rename.md
+++ b/tests/testthat/_snaps/dplyr-rename.md
@@ -1,3 +1,39 @@
+# rename verbs require names for virtual identifiers
+
+    Code
+      rename_col(se, id = .sample)
+    Condition
+      Error:
+      ! Cannot use .sample because `colnames(exp)` does not exist.
+      i Create it with `mutate_col(exp, .sample = ...)`.
+
+---
+
+    Code
+      rename_row(se, id = .variable)
+    Condition
+      Error:
+      ! Cannot use .variable because `rownames(exp)` does not exist.
+      i Create it with `mutate_row(exp, .variable = ...)`.
+
+---
+
+    Code
+      rename_col(se, .sample = group)
+    Condition
+      Error:
+      ! Column .sample in `sample_info` is reserved for dimension names.
+      i Choose a different metadata column name.
+
+---
+
+    Code
+      rename_row(se, .variable = type)
+    Condition
+      Error:
+      ! Column .variable in `var_info` is reserved for dimension names.
+      i Choose a different metadata column name.
+
 # trying to rename non-existing columns throws an error
 
     Code

--- a/tests/testthat/_snaps/dplyr-select.md
+++ b/tests/testthat/_snaps/dplyr-select.md
@@ -1,3 +1,48 @@
+# select verbs require names for virtual identifiers
+
+    Code
+      select_col(se, .sample)
+    Condition
+      Error:
+      ! Cannot use .sample because `colnames(exp)` does not exist.
+      i Create it with `mutate_col(exp, .sample = ...)`.
+
+---
+
+    Code
+      select_row(se, .variable)
+    Condition
+      Error:
+      ! Cannot use .variable because `rownames(exp)` does not exist.
+      i Create it with `mutate_row(exp, .variable = ...)`.
+
+---
+
+    Code
+      select_col(se, dplyr::all_of(".sample"))
+    Condition
+      Error:
+      ! Cannot use .sample because `colnames(exp)` does not exist.
+      i Create it with `mutate_col(exp, .sample = ...)`.
+
+---
+
+    Code
+      select_col(se, .sample = group)
+    Condition
+      Error:
+      ! Column .sample in `sample_info` is reserved for dimension names.
+      i Choose a different metadata column name.
+
+---
+
+    Code
+      select_row(se, .variable = type)
+    Condition
+      Error:
+      ! Column .variable in `var_info` is reserved for dimension names.
+      i Choose a different metadata column name.
+
 # selecting 'sample' column raises an error
 
     Code

--- a/tests/testthat/_snaps/dplyr-slice.md
+++ b/tests/testthat/_snaps/dplyr-slice.md
@@ -16,6 +16,14 @@
       ! Cannot use .variable because `rownames(exp)` does not exist.
       i Create it with `mutate_row(exp, .variable = ...)`.
 
+# named slice expressions do not match internal arguments
+
+    Code
+      slice_row(se, id = .variable)
+    Condition
+      Error:
+      ! Arguments in `...` must be passed by position, not name. x Problematic argument: * id = .variable
+
 # slice with non-existing columns raises an error
 
     Code

--- a/tests/testthat/_snaps/dplyr-slice.md
+++ b/tests/testthat/_snaps/dplyr-slice.md
@@ -1,3 +1,21 @@
+# slice verbs require names for virtual identifiers
+
+    Code
+      slice_max_col(se, order_by = .sample, n = 1)
+    Condition
+      Error:
+      ! Cannot use .sample because `colnames(exp)` does not exist.
+      i Create it with `mutate_col(exp, .sample = ...)`.
+
+---
+
+    Code
+      slice_min_row(se, order_by = .variable, n = 1)
+    Condition
+      Error:
+      ! Cannot use .variable because `rownames(exp)` does not exist.
+      i Create it with `mutate_row(exp, .variable = ...)`.
+
 # slice with non-existing columns raises an error
 
     Code

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -54,6 +54,13 @@ create_test_se <- function(samples, variables) {
   se
 }
 
+create_unnamed_test_se <- function() {
+  se <- create_test_se(c("S1", "S2", "S3"), c("V1", "V2", "V3"))
+  colnames(se) <- NULL
+  rownames(se) <- NULL
+  se
+}
+
 create_test_exp_2 <- function() {
   expr_mat <- create_expr_mat(c("S1", "S2", "S3"), c("V1", "V2", "V3"))
   sample_info <- tibble::tibble(

--- a/tests/testthat/test-dplyr-arrange.R
+++ b/tests/testthat/test-dplyr-arrange.R
@@ -35,6 +35,19 @@ test_that("arrange verbs support SummarizedExperiment", {
   expect_identical(S4Vectors::metadata(result)$marker, "preserved")
 })
 
+test_that("arrange verbs require names for virtual identifiers", {
+  se <- create_unnamed_test_se()
+
+  result <- se |>
+    arrange_col(group) |>
+    arrange_row(type)
+  expect_null(colnames(result))
+  expect_null(rownames(result))
+
+  expect_snapshot(arrange_col(se, .sample), error = TRUE)
+  expect_snapshot(arrange_row(se, .variable), error = TRUE)
+})
+
 
 test_that("arranging by multiple columns works", {
   exp <- create_test_exp(c("S1", "S2", "S3", "S4"), c("V1", "V2"))

--- a/tests/testthat/test-dplyr-arrange.R
+++ b/tests/testthat/test-dplyr-arrange.R
@@ -46,6 +46,7 @@ test_that("arrange verbs require names for virtual identifiers", {
 
   expect_snapshot(arrange_col(se, .sample), error = TRUE)
   expect_snapshot(arrange_row(se, .variable), error = TRUE)
+  expect_snapshot(arrange_row(se, id = .variable), error = TRUE)
 })
 
 

--- a/tests/testthat/test-dplyr-filter.R
+++ b/tests/testthat/test-dplyr-filter.R
@@ -34,6 +34,19 @@ test_that("filter verbs support SummarizedExperiment", {
   expect_identical(S4Vectors::metadata(result)$marker, "preserved")
 })
 
+test_that("filter verbs require names for virtual identifiers", {
+  se <- create_unnamed_test_se()
+
+  result <- se |>
+    filter_col(group == "A") |>
+    filter_row(type == "B")
+  expect_null(colnames(result))
+  expect_null(rownames(result))
+
+  expect_snapshot(filter_col(se, .sample == "S1"), error = TRUE)
+  expect_snapshot(filter_row(se, .variable == "V1"), error = TRUE)
+})
+
 test_that("filtering SummarizedExperiment uses virtual identifiers", {
   se <- create_test_se(c("S1", "S2", "S3"), c("V1", "V2", "V3"))
   SummarizedExperiment::assays(se)$scaled <-

--- a/tests/testthat/test-dplyr-join.R
+++ b/tests/testthat/test-dplyr-join.R
@@ -54,6 +54,35 @@ test_that("all join verbs support SummarizedExperiment", {
   expect_identical(rownames(results[[8]]), "V2")
 })
 
+test_that("join verbs require names for virtual identifiers", {
+  se <- create_unnamed_test_se()
+  obs_info <- tibble::tibble(group = "A", batch = 1)
+  var_info <- tibble::tibble(type = "B", score = 2)
+
+  result <- se |>
+    left_join_col(obs_info, by = "group") |>
+    left_join_row(var_info, by = "type")
+  expect_null(colnames(result))
+  expect_null(rownames(result))
+
+  expect_snapshot(
+    left_join_col(se, tibble::tibble(.sample = "S1"), by = ".sample"),
+    error = TRUE
+  )
+  expect_snapshot(
+    left_join_row(se, tibble::tibble(.variable = "V1"), by = ".variable"),
+    error = TRUE
+  )
+  expect_snapshot(
+    left_join_col(
+      se,
+      tibble::tibble(group = "A", .sample = "S1"),
+      by = "group"
+    ),
+    error = TRUE
+  )
+})
+
 
 test_that("left_join_col handles missing values correctly", {
   exp <- create_test_exp(c("S1", "S2", "S3"), c("V1", "V2", "V3"))

--- a/tests/testthat/test-dplyr-mutate.R
+++ b/tests/testthat/test-dplyr-mutate.R
@@ -38,6 +38,22 @@ test_that("mutate verbs support SummarizedExperiment", {
   expect_identical(S4Vectors::metadata(result)$marker, "preserved")
 })
 
+test_that("named mutations do not match internal arguments", {
+  se <- create_test_se(c("S1", "S2", "S3"), c("V1", "V2", "V3"))
+
+  result <- mutate_row(
+    se,
+    id = .variable,
+    id_column = .variable
+  )
+
+  expect_identical(SummarizedExperiment::rowData(result)$id, rownames(se))
+  expect_identical(
+    SummarizedExperiment::rowData(result)$id_column,
+    rownames(se)
+  )
+})
+
 test_that("mutate verbs handle missing SummarizedExperiment names", {
   se <- create_unnamed_test_se()
 
@@ -55,6 +71,7 @@ test_that("mutate verbs handle missing SummarizedExperiment names", {
 
   expect_snapshot(mutate_col(se, copied = .sample), error = TRUE)
   expect_snapshot(mutate_row(se, copied = .variable), error = TRUE)
+  expect_snapshot(mutate_row(se, id = .variable), error = TRUE)
   expect_snapshot(mutate_col(se, copied = .data$.sample), error = TRUE)
 })
 

--- a/tests/testthat/test-dplyr-mutate.R
+++ b/tests/testthat/test-dplyr-mutate.R
@@ -38,6 +38,26 @@ test_that("mutate verbs support SummarizedExperiment", {
   expect_identical(S4Vectors::metadata(result)$marker, "preserved")
 })
 
+test_that("mutate verbs handle missing SummarizedExperiment names", {
+  se <- create_unnamed_test_se()
+
+  metadata_result <- se |>
+    mutate_col(batch = 1:3) |>
+    mutate_row(score = 3:1)
+  expect_null(colnames(metadata_result))
+  expect_null(rownames(metadata_result))
+
+  named_result <- se |>
+    mutate_col(.sample = c("A", "B", "C")) |>
+    mutate_row(.variable = c("X", "Y", "Z"))
+  expect_identical(colnames(named_result), c("A", "B", "C"))
+  expect_identical(rownames(named_result), c("X", "Y", "Z"))
+
+  expect_snapshot(mutate_col(se, copied = .sample), error = TRUE)
+  expect_snapshot(mutate_row(se, copied = .variable), error = TRUE)
+  expect_snapshot(mutate_col(se, copied = .data$.sample), error = TRUE)
+})
+
 test_that("SummarizedExperiment virtual identifier names are reserved", {
   obs_se <- create_test_se(c("S1", "S2", "S3"), c("V1", "V2", "V3"))
   SummarizedExperiment::colData(obs_se)$.sample <- c("A", "B", "C")

--- a/tests/testthat/test-dplyr-rename.R
+++ b/tests/testthat/test-dplyr-rename.R
@@ -43,6 +43,21 @@ test_that("rename verbs support SummarizedExperiment", {
   )
 })
 
+test_that("rename verbs require names for virtual identifiers", {
+  se <- create_unnamed_test_se()
+
+  result <- se |>
+    rename_col(condition = group) |>
+    rename_row(class = type)
+  expect_null(colnames(result))
+  expect_null(rownames(result))
+
+  expect_snapshot(rename_col(se, id = .sample), error = TRUE)
+  expect_snapshot(rename_row(se, id = .variable), error = TRUE)
+  expect_snapshot(rename_col(se, .sample = group), error = TRUE)
+  expect_snapshot(rename_row(se, .variable = type), error = TRUE)
+})
+
 
 test_that("trying to rename non-existing columns throws an error", {
   exp <- create_test_exp(c("S1", "S2", "S3"), c("V1", "V2", "V3"))

--- a/tests/testthat/test-dplyr-select.R
+++ b/tests/testthat/test-dplyr-select.R
@@ -47,6 +47,22 @@ test_that("select verbs support SummarizedExperiment", {
   )
 })
 
+test_that("select verbs require names for virtual identifiers", {
+  se <- create_unnamed_test_se()
+
+  result <- se |>
+    select_col(group) |>
+    select_row(type)
+  expect_null(colnames(result))
+  expect_null(rownames(result))
+
+  expect_snapshot(select_col(se, .sample), error = TRUE)
+  expect_snapshot(select_row(se, .variable), error = TRUE)
+  expect_snapshot(select_col(se, dplyr::all_of(".sample")), error = TRUE)
+  expect_snapshot(select_col(se, .sample = group), error = TRUE)
+  expect_snapshot(select_row(se, .variable = type), error = TRUE)
+})
+
 
 test_that("selecting 'sample' column raises an error", {
   exp <- create_test_exp_2()

--- a/tests/testthat/test-dplyr-slice.R
+++ b/tests/testthat/test-dplyr-slice.R
@@ -50,6 +50,25 @@ test_that("every slice verb supports SummarizedExperiment", {
   purrr::walk(var_results, ~ expect_equal(nrow(.x), 2))
 })
 
+test_that("slice verbs require names for virtual identifiers", {
+  se <- create_unnamed_test_se()
+
+  result <- se |>
+    slice_col(1, 3) |>
+    slice_row(1, 2)
+  expect_null(colnames(result))
+  expect_null(rownames(result))
+
+  expect_snapshot(
+    slice_max_col(se, order_by = .sample, n = 1),
+    error = TRUE
+  )
+  expect_snapshot(
+    slice_min_row(se, order_by = .variable, n = 1),
+    error = TRUE
+  )
+})
+
 
 test_that("slice_head_col works", {
   exp <- create_test_exp(c("S1", "S2", "S3", "S4", "S5"), c("V1", "V2"))

--- a/tests/testthat/test-dplyr-slice.R
+++ b/tests/testthat/test-dplyr-slice.R
@@ -69,6 +69,12 @@ test_that("slice verbs require names for virtual identifiers", {
   )
 })
 
+test_that("named slice expressions do not match internal arguments", {
+  se <- create_unnamed_test_se()
+
+  expect_snapshot(slice_row(se, id = .variable), error = TRUE)
+})
+
 
 test_that("slice_head_col works", {
   exp <- create_test_exp(c("S1", "S2", "S3", "S4", "S5"), c("V1", "V2"))


### PR DESCRIPTION
## Summary

- Stop synthesizing row-number identifiers when a `SummarizedExperiment` has `NULL` dimension names.
- Preserve unnamed dimensions for metadata-only tidy operations and raise an actionable error when `.sample` or `.variable` is referenced.
- Keep `mutate_col(.sample = ...)` and `mutate_row(.variable = ...)` as the explicit paths for creating missing names.
- Capture named mutate and arrange expressions before internal dispatch, preventing user columns such as `id` and `id_column` from partially matching internal arguments.
- Add regression coverage across mutate, filter, arrange, select, rename, slice, and join helpers.
- Document the behavior in `NEWS.md` with the live PR reference.

## Verification

```r
exp <- real_experiment2
rownames(exp) <- NULL
colnames(exp) <- NULL
mutate_row(exp, id = .variable)
#> Error: Cannot use .variable because `rownames(exp)` does not exist.
```

- `air format .`
- Focused dplyr tests: 293 assertions passed
- Full test suite: 648 assertions passed
- `devtools::check(error_on = "warning")`: 0 errors, 0 warnings; one environment-only system clock note
- `git diff --check` after the NEWS-only follow-up